### PR TITLE
Spark savings

### DIFF
--- a/Sky Atlas/Sky Atlas.html
+++ b/Sky Atlas/Sky Atlas.html
@@ -28837,7 +28837,7 @@
         </tr>
         <tr>
           <td>
-            <dfn>Ethereum Mainnet - Spark Savings v2 ETH Instance Configuration Document</dfn>
+            <dfn>Ethereum Mainnet - Spark Savings v2 ETH Instance Configuration Document Location</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
@@ -28845,7 +28845,7 @@
         </tr>
         <tr>
           <td>
-            <dfn>Ethereum Mainnet - Spark Savings v2 USDC Instance Configuration Document</dfn>
+            <dfn>Ethereum Mainnet - Spark Savings v2 USDC Instance Configuration Document Location</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
@@ -28853,7 +28853,7 @@
         </tr>
         <tr>
           <td>
-            <dfn>Ethereum Mainnet - Spark Savings v2 USDT Instance Configuration Document</dfn>
+            <dfn>Ethereum Mainnet - Spark Savings v2 USDT Instance Configuration Document Location</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
@@ -28973,7 +28973,7 @@
         </tr>
         <tr>
           <td>
-            <dfn>Avalanche - Aave v3 USDC Vault Instance Configuration Document</dfn>
+            <dfn>Avalanche - Aave v3 USDC Vault Instance Configuration Document Location</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
@@ -28989,7 +28989,7 @@
         </tr>
         <tr>
           <td>
-            <dfn>Avalanche - Spark Savings v2 USDC Instance Configuration Document</dfn>
+            <dfn>Avalanche - Spark Savings v2 USDC Instance Configuration Document Location</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
@@ -36387,11 +36387,11 @@
         </tr>
         <tr>
           <td>
-            <dfn>Asset Supplied By SLL</dfn>
+            <dfn>Asset Supplied By Users</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>ETH</td>
+          <td>wETH</td>
         </tr>
         <tr>
           <td>
@@ -36427,6 +36427,54 @@
         </tr>
         <tr>
           <td>
+            <dfn>Rate Limit IDs</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The specific <code>RateLimitID</code>(s) for this conduit's inflow and outflow will be specified in a future iteration of the Spark Artifact.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The specific <code>maxAmount</code> and <code>slope</code> for this conduit's inflow/outflow are not defined for this Instance.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Off-chain Operational Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain specific off-chain parameters for this Instance.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Instance-specific Operational Processes</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain operational procedures or monitoring requirements unique to this Instance that deviate from or otherwise supplement the general SLL processes.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Instance-specific Operational Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain operational parameters or configuration details unique to this Instance that deviate from or otherwise supplement the general SLL parameters.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Contract Addresses</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein define the Instance contract addresses.</td>
+        </tr>
+        <tr>
+          <td>
             <dfn>Spark Vault v2 Implementation</dfn>
           </td>
           <td>Spark</td>
@@ -36459,46 +36507,6 @@
         </tr>
         <tr>
           <td>
-            <dfn>Rate Limit IDs</dfn>
-          </td>
-          <td>Spark</td>
-          <td>Core</td>
-          <td>The specific <code>RateLimitID</code>(s) for this conduit's inflow and outflow will be specified in a future iteration of the Spark Artifact.</td>
-        </tr>
-        <tr>
-          <td>
-            <dfn>Rate Limits</dfn>
-          </td>
-          <td>Spark</td>
-          <td>Core</td>
-          <td>The current <code>maxAmount</code> and <code>slope</code> for this conduit's inflow/outflow are defined in the subdocuments herein.</td>
-        </tr>
-        <tr>
-          <td>
-            <dfn>Inflow Rate Limits</dfn>
-          </td>
-          <td>Spark</td>
-          <td>Core</td>
-          <td>The inflow rate limits are:
-            <ul>
-              <li><code>maxAmount</code>: Unlimited</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <dfn>Outflow Rate Limits</dfn>
-          </td>
-          <td>Spark</td>
-          <td>Core</td>
-          <td>The outflow rate limits are:
-            <ul>
-              <li><code>maxAmount</code>: Unlimited</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>
             <dfn>Risk Parameters Current Configuration</dfn>
           </td>
           <td>Spark</td>
@@ -36518,22 +36526,38 @@
               <li>Current yield (at launch): 0%</li>
             </ul>
           </td>
-        </tr>        
-        <tr>
-          <td>
-            <dfn>Off-chain Operational Parameters</dfn>
-          </td>
-          <td>Spark</td>
-          <td>Core</td>
-          <td>The documents herein contain specific off-chain parameters for this Instance.</td>
         </tr>
         <tr>
           <td>
-            <dfn>Instance-specific Operational Processes</dfn>
+            <dfn>Rate Limits</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The documents herein contain operational procedures or monitoring requirements unique to this Instance that deviate from or otherwise supplement the general SLL processes.</td>
+          <td>The current <code>maxAmount</code> for this conduit's take and transferAssets operations are defined in the subdocuments herein.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Take Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The take rate limits are:
+            <ul>
+              <li><code>maxAmount</code>: Unlimited</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>TransferAssets Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The transferAssets rate limits are:
+            <ul>
+              <li><code>maxAmount</code>: Unlimited</li>
+            </ul>
+          </td>
         </tr>
         <tr>
           <td>
@@ -36585,7 +36609,7 @@
         </tr>
         <tr>
           <td>
-            <dfn>Asset Supplied By SLL</dfn>
+            <dfn>Asset Supplied By Users</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
@@ -36625,6 +36649,54 @@
         </tr>
         <tr>
           <td>
+            <dfn>Rate Limit IDs</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The specific <code>RateLimitID</code>(s) for this conduit's inflow and outflow will be specified in a future iteration of the Spark Artifact.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The specific <code>maxAmount</code> and <code>slope</code> for this conduit's inflow/outflow are not defined for this Instance.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Off-chain Operational Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain specific off-chain parameters for this Instance.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Instance-specific Operational Processes</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain operational procedures or monitoring requirements unique to this Instance that deviate from or otherwise supplement the general SLL processes.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Instance-specific Operational Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain operational parameters or configuration details unique to this Instance that deviate from or otherwise supplement the general SLL parameters.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Contract Addresses</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein define the Instance contract addresses.</td>
+        </tr>
+        <tr>
+          <td>
             <dfn>Spark Vault v2 Implementation</dfn>
           </td>
           <td>Spark</td>
@@ -36654,46 +36726,6 @@
           <td>Spark</td>
           <td>Core</td>
           <td><code>0x1601843c5E9bC251A3272907010AFa41Fa18347E</code></td>
-        </tr>        
-        <tr>
-          <td>
-            <dfn>Rate Limit IDs</dfn>
-          </td>
-          <td>Spark</td>
-          <td>Core</td>
-          <td>The specific <code>RateLimitID</code>(s) for this conduit's inflow and outflow will be specified in a future iteration of the Spark Artifact.</td>
-        </tr>
-        <tr>
-          <td>
-            <dfn>Rate Limits</dfn>
-          </td>
-          <td>Spark</td>
-          <td>Core</td>
-          <td>The current <code>maxAmount</code> and <code>slope</code> for this conduit's inflow/outflow are defined in the subdocuments herein.</td>
-        </tr>
-        <tr>
-          <td>
-            <dfn>Inflow Rate Limits</dfn>
-          </td>
-          <td>Spark</td>
-          <td>Core</td>
-          <td>The inflow rate limits are:
-            <ul>
-              <li><code>maxAmount</code>: Unlimited</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <dfn>Outflow Rate Limits</dfn>
-          </td>
-          <td>Spark</td>
-          <td>Core</td>
-          <td>The outflow rate limits are:
-            <ul>
-              <li><code>maxAmount</code>: Unlimited</li>
-            </ul>
-          </td>
         </tr>
         <tr>
           <td>
@@ -36719,19 +36751,35 @@
         </tr>
         <tr>
           <td>
-            <dfn>Off-chain Operational Parameters</dfn>
+            <dfn>Rate Limits</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The documents herein contain specific off-chain parameters for this Instance.</td>
+          <td>The current <code>maxAmount</code> for this conduit's take and transferAssets operations are defined in the subdocuments herein.</td>
         </tr>
         <tr>
           <td>
-            <dfn>Instance-specific Operational Processes</dfn>
+            <dfn>Take Rate Limits</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The documents herein contain operational procedures or monitoring requirements unique to this Instance that deviate from or otherwise supplement the general SLL processes.</td>
+          <td>The take rate limits are:
+            <ul>
+              <li><code>maxAmount</code>: Unlimited</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>TransferAssets Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The transferAssets rate limits are:
+            <ul>
+              <li><code>maxAmount</code>: Unlimited</li>
+            </ul>
+          </td>
         </tr>
         <tr>
           <td>
@@ -36783,7 +36831,7 @@
         </tr>
         <tr>
           <td>
-            <dfn>Asset Supplied By SLL</dfn>
+            <dfn>Asset Supplied By Users</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
@@ -36823,6 +36871,54 @@
         </tr>
         <tr>
           <td>
+            <dfn>Rate Limit IDs</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The specific <code>RateLimitID</code>(s) for this conduit's inflow and outflow will be specified in a future iteration of the Spark Artifact.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The specific <code>maxAmount</code> and <code>slope</code> for this conduit's inflow/outflow are not defined for this Instance.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Off-chain Operational Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain specific off-chain parameters for this Instance.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Instance-specific Operational Processes</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain operational procedures or monitoring requirements unique to this Instance that deviate from or otherwise supplement the general SLL processes.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Instance-specific Operational Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain operational parameters or configuration details unique to this Instance that deviate from or otherwise supplement the general SLL parameters.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Contract Addresses</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein define the Instance contract addresses.</td>
+        </tr>
+        <tr>
+          <td>
             <dfn>Spark Vault v2 Implementation</dfn>
           </td>
           <td>Spark</td>
@@ -36855,46 +36951,6 @@
         </tr>
         <tr>
           <td>
-            <dfn>Rate Limit IDs</dfn>
-          </td>
-          <td>Spark</td>
-          <td>Core</td>
-          <td>The specific <code>RateLimitID</code>(s) for this conduit's inflow and outflow will be specified in a future iteration of the Spark Artifact.</td>
-        </tr>
-        <tr>
-          <td>
-            <dfn>Rate Limits</dfn>
-          </td>
-          <td>Spark</td>
-          <td>Core</td>
-          <td>The current <code>maxAmount</code> and <code>slope</code> for this conduit's inflow/outflow are defined in the subdocuments herein.</td>
-        </tr>
-        <tr>
-          <td>
-            <dfn>Inflow Rate Limits</dfn>
-          </td>
-          <td>Spark</td>
-          <td>Core</td>
-          <td>The inflow rate limits are:
-            <ul>
-              <li><code>maxAmount</code>: Unlimited</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <dfn>Outflow Rate Limits</dfn>
-          </td>
-          <td>Spark</td>
-          <td>Core</td>
-          <td>The outflow rate limits are:
-            <ul>
-              <li><code>maxAmount</code>: Unlimited</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>
             <dfn>Risk Parameters Current Configuration</dfn>
           </td>
           <td>Spark</td>
@@ -36917,19 +36973,35 @@
         </tr>
         <tr>
           <td>
-            <dfn>Off-chain Operational Parameters</dfn>
+            <dfn>Rate Limits</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The documents herein contain specific off-chain parameters for this Instance.</td>
+          <td>The current <code>maxAmount</code> for this conduit's take and transferAssets operations are defined in the subdocuments herein.</td>
         </tr>
         <tr>
           <td>
-            <dfn>Instance-specific Operational Processes</dfn>
+            <dfn>Take Rate Limits</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The documents herein contain operational procedures or monitoring requirements unique to this Instance that deviate from or otherwise supplement the general SLL processes.</td>
+          <td>The take rate limits are:
+            <ul>
+              <li><code>maxAmount</code>: Unlimited</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>TransferAssets Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The transferAssets rate limits are:
+            <ul>
+              <li><code>maxAmount</code>: Unlimited</li>
+            </ul>
+          </td>
         </tr>
         <tr>
           <td>
@@ -37954,7 +38026,7 @@
         </tr>
         <tr>
           <td>
-            <dfn>Asset Supplied By SLL</dfn>
+            <dfn>Asset Supplied By Users</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
@@ -37994,6 +38066,54 @@
         </tr>
         <tr>
           <td>
+            <dfn>Rate Limit IDs</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The specific <code>RateLimitID</code>(s) for this conduit's inflow and outflow will be specified in a future iteration of the Spark Artifact.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The specific <code>maxAmount</code> and <code>slope</code> for this conduit's inflow/outflow are not defined for this Instance.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Off-chain Operational Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain specific off-chain parameters for this Instance.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Instance-specific Operational Processes</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain operational procedures or monitoring requirements unique to this Instance that deviate from or otherwise supplement the general SLL processes.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Instance-specific Operational Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain operational parameters or configuration details unique to this Instance that deviate from or otherwise supplement the general SLL parameters.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Contract Addresses</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein define the Instance contract addresses.</td>
+        </tr>
+        <tr>
+          <td>
             <dfn>Spark Vault v2 Implementation</dfn>
           </td>
           <td>Spark</td>
@@ -38023,46 +38143,6 @@
           <td>Spark</td>
           <td>Core</td>
           <td><code>0xecE6B0E8a54c2f44e066fBb9234e7157B15b7FeC</code></td>
-        </tr>        
-        <tr>
-          <td>
-            <dfn>Rate Limit IDs</dfn>
-          </td>
-          <td>Spark</td>
-          <td>Core</td>
-          <td>The specific <code>RateLimitID</code>(s) for this conduit's inflow and outflow will be specified in a future iteration of the Spark Artifact.</td>
-        </tr>
-        <tr>
-          <td>
-            <dfn>Rate Limits</dfn>
-          </td>
-          <td>Spark</td>
-          <td>Core</td>
-          <td>The current <code>maxAmount</code> and <code>slope</code> for this conduit's inflow/outflow are defined in the subdocuments herein.</td>
-        </tr>
-        <tr>
-          <td>
-            <dfn>Inflow Rate Limits</dfn>
-          </td>
-          <td>Spark</td>
-          <td>Core</td>
-          <td>The inflow rate limits are:
-            <ul>
-              <li><code>maxAmount</code>: Unlimited</li>
-            </ul>
-          </td>
-        </tr>
-        <tr>
-          <td>
-            <dfn>Outflow Rate Limits</dfn>
-          </td>
-          <td>Spark</td>
-          <td>Core</td>
-          <td>The outflow rate limits are:
-            <ul>
-              <li><code>maxAmount</code>: Unlimited</li>
-            </ul>
-          </td>
         </tr>
         <tr>
           <td>
@@ -38088,19 +38168,35 @@
         </tr>
         <tr>
           <td>
-            <dfn>Off-chain Operational Parameters</dfn>
+            <dfn>Rate Limits</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The documents herein contain specific off-chain parameters for this Instance.</td>
+          <td>The current <code>maxAmount</code> for this conduit's take and transferAssets operations are defined in the subdocuments herein.</td>
         </tr>
         <tr>
           <td>
-            <dfn>Instance-specific Operational Processes</dfn>
+            <dfn>Take Rate Limits</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The documents herein contain operational procedures or monitoring requirements unique to this Instance that deviate from or otherwise supplement the general SLL processes.</td>
+          <td>The take rate limits are:
+            <ul>
+              <li><code>maxAmount</code>: Unlimited</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>TransferAssets Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The transferAssets rate limits are:
+            <ul>
+              <li><code>maxAmount</code>: Unlimited</li>
+            </ul>
+          </td>
         </tr>
         <tr>
           <td>

--- a/Sky Atlas/Sky Atlas.html
+++ b/Sky Atlas/Sky Atlas.html
@@ -28977,7 +28977,7 @@
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>This Instance's associated Instance Configuration Document is located at <dfn>Avalanche -  Aave v3 USDC Vault Instance Configuration Document</dfn>.</td>
+          <td>This Instance's associated Instance Configuration Document is located at <dfn>Avalanche - Aave v3 USDC Vault Instance Configuration Document</dfn>.</td>
         </tr>
         <tr>
           <td>
@@ -37752,7 +37752,7 @@
         </tr>
         <tr>
           <td>
-            <dfn>Avalanche -  Aave v3 USDC Vault Instance Configuration Document</dfn>
+            <dfn>Avalanche - Aave v3 USDC Vault Instance Configuration Document</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>

--- a/Sky Atlas/Sky Atlas.html
+++ b/Sky Atlas/Sky Atlas.html
@@ -28833,31 +28833,31 @@
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The Ethereum Mainnet Instances Directory of the Spark Savings V2 with Active Status are stored herein.</td>
+          <td>The Ethereum Mainnet Instances Directory of the Spark Savings v2 with <code>Active</code> Status are stored herein.</td>
         </tr>
         <tr>
           <td>
-            <dfn>Ethereum Mainnet - Spark Savings ETH Instance Configuration Document</dfn>
+            <dfn>Ethereum Mainnet - Spark Savings v2 ETH Instance Configuration Document</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>This Instance's associated Instance Configuration Document is located at <dfn>Ethereum Mainnet - Spark Savings ETH Instance Configuration Document</dfn>.</td>
+          <td>This Instance's associated Instance Configuration Document is located at <dfn>Ethereum Mainnet - Spark Savings v2 ETH Instance Configuration Document</dfn>.</td>
         </tr>
         <tr>
           <td>
-            <dfn>Ethereum Mainnet - Spark Savings USDC Instance Configuration Document</dfn>
+            <dfn>Ethereum Mainnet - Spark Savings v2 USDC Instance Configuration Document</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>This Instance's associated Instance Configuration Document is located at <dfn>Ethereum Mainnet - Spark Savings USDC Instance Configuration Document</dfn>.</td>
+          <td>This Instance's associated Instance Configuration Document is located at <dfn>Ethereum Mainnet - Spark Savings v2 USDC Instance Configuration Document</dfn>.</td>
         </tr>
         <tr>
           <td>
-            <dfn>Ethereum Mainnet - Spark Savings USDT Instance Configuration Document</dfn>
+            <dfn>Ethereum Mainnet - Spark Savings v2 USDT Instance Configuration Document</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>This Instance's associated Instance Configuration Document is located at <dfn>Ethereum Mainnet - Spark Savings USDT Instance Configuration Document</dfn>.</td>
+          <td>This Instance's associated Instance Configuration Document is located at <dfn>Ethereum Mainnet - Spark Savings v2 USDT Instance Configuration Document</dfn>.</td>
         </tr>                
         <tr>
           <td>
@@ -28961,7 +28961,7 @@
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The documents herein contain a Directory of all Instances on the Avalanche of the Allocation System Primitive with Instance status of Active.</td>
+          <td>The documents herein contain a Directory of all Instances on Avalanche of the Allocation System Primitive with Instance status of <code>Active</code>.</td>
         </tr>
         <tr>
           <td>
@@ -28973,7 +28973,7 @@
         </tr>
         <tr>
           <td>
-            <dfn>Avalanche -  Aave v3 USDC Vault Instance Configuration Document</dfn>
+            <dfn>Avalanche - Aave v3 USDC Vault Instance Configuration Document</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
@@ -28985,15 +28985,15 @@
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The Avalanche Instances Directory of the Spark Savings V2 with Active Status are stored herein.</td>
+          <td>The Avalanche Instances Directory of the Spark Savings v2 with <code>Active</code> Status are stored herein.</td>
         </tr>
         <tr>
           <td>
-            <dfn>Avalanche - Spark Savings USDC Instance Configuration Document</dfn>
+            <dfn>Avalanche - Spark Savings v2 USDC Instance Configuration Document</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>This Instance's associated Instance Configuration Document is located at <dfn>Avalanche - Spark Savings USDC Instance Configuration Document</dfn>.</td>
+          <td>This Instance's associated Instance Configuration Document is located at <dfn>Avalanche - Spark Savings v2 USDC Instance Configuration Document</dfn>.</td>
         </tr>
         <tr>
           <td>
@@ -36335,15 +36335,15 @@
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The Ethereum Mainnet Instances of the Spark Savings V2 with <code>Active</code> Status are stored herein.</td>
+          <td>The Ethereum Mainnet Instances of the Spark Savings v2 with <code>Active</code> Status are stored herein.</td>
         </tr>
         <tr>
           <td>
-            <dfn>Ethereum Mainnet - Spark Savings ETH Instance Configuration Document</dfn>
+            <dfn>Ethereum Mainnet - Spark Savings v2 ETH Instance Configuration Document</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The documents herein contain the Instance Configuration Document for the Spark Savings ETH Instance.</td>
+          <td>The documents herein contain the Instance Configuration Document for the Spark Savings v2 ETH Instance.</td>
         </tr>
         <tr>
           <td>
@@ -36359,7 +36359,7 @@
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The documents herein define the parameters of the Spark Savings ETH Instance of the Allocation System Primitive.</td>
+          <td>The documents herein define the parameters of the Spark Savings v2 ETH Instance of the Allocation System Primitive.</td>
         </tr>
         <tr>
           <td>
@@ -36481,7 +36481,7 @@
           <td>Core</td>
           <td>The inflow rate limits are:
             <ul>
-              <li><code>maxAmount</code>: unlimited</li>
+              <li><code>maxAmount</code>: Unlimited</li>
             </ul>
           </td>
         </tr>
@@ -36537,11 +36537,11 @@
         </tr>
         <tr>
           <td>
-            <dfn>Ethereum Mainnet - Spark Savings USDC Instance Configuration Document</dfn>
+            <dfn>Ethereum Mainnet - Spark Savings v2 USDC Instance Configuration Document</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The documents herein contain the Instance Configuration Document for the Spark Savings USDC Instance.</td>
+          <td>The documents herein contain the Instance Configuration Document for the Spark Savings v2 USDC Instance.</td>
         </tr>
         <tr>
           <td>
@@ -36557,7 +36557,7 @@
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The documents herein define the parameters of the Spark Savings USDC Instance of the Allocation System Primitive.</td>
+          <td>The documents herein define the parameters of the Spark Savings v2 USDC Instance of the Allocation System Primitive.</td>
         </tr>
         <tr>
           <td>
@@ -36679,7 +36679,7 @@
           <td>Core</td>
           <td>The inflow rate limits are:
             <ul>
-              <li><code>maxAmount</code>: unlimited</li>
+              <li><code>maxAmount</code>: Unlimited</li>
             </ul>
           </td>
         </tr>
@@ -36735,11 +36735,11 @@
         </tr>
         <tr>
           <td>
-            <dfn>Ethereum Mainnet - Spark Savings USDT Instance Configuration Document</dfn>
+            <dfn>Ethereum Mainnet - Spark Savings v2 USDT Instance Configuration Document</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The documents herein contain the Instance Configuration Document for the Spark Savings USDT Instance.</td>
+          <td>The documents herein contain the Instance Configuration Document for the Spark Savings v2 USDT Instance.</td>
         </tr>
         <tr>
           <td>
@@ -36755,7 +36755,7 @@
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The documents herein define the parameters of the Spark Savings USDT Instance of the Allocation System Primitive.</td>
+          <td>The documents herein define the parameters of the Spark Savings v2 USDT Instance of the Allocation System Primitive.</td>
         </tr>
         <tr>
           <td>
@@ -36877,7 +36877,7 @@
           <td>Core</td>
           <td>The inflow rate limits are:
             <ul>
-              <li><code>maxAmount</code>: unlimited</li>
+              <li><code>maxAmount</code>: Unlimited</li>
             </ul>
           </td>
         </tr>
@@ -37902,15 +37902,15 @@
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The Avalanche Instances of the Spark Savings V2 with <code>Active</code> Status are stored herein.</td>
+          <td>The Avalanche Instances of the Spark Savings v2 with <code>Active</code> Status are stored herein.</td>
         </tr>
         <tr>
           <td>
-            <dfn>Avalanche - Spark Savings USDC Instance Configuration Document</dfn>
+            <dfn>Avalanche - Spark Savings v2 USDC Instance Configuration Document</dfn>
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The documents herein contain the Instance Configuration Document for the Spark Savings USDC Instance.</td>
+          <td>The documents herein contain the Instance Configuration Document for the Spark Savings v2 USDC Instance.</td>
         </tr>
         <tr>
           <td>
@@ -37926,7 +37926,7 @@
           </td>
           <td>Spark</td>
           <td>Core</td>
-          <td>The documents herein define the parameters of the Spark Savings USDC Instance of the Allocation System Primitive.</td>
+          <td>The documents herein define the parameters of the Spark Savings v2 USDC Instance of the Allocation System Primitive.</td>
         </tr>
         <tr>
           <td>
@@ -38048,7 +38048,7 @@
           <td>Core</td>
           <td>The inflow rate limits are:
             <ul>
-              <li><code>maxAmount</code>: unlimited</li>
+              <li><code>maxAmount</code>: Unlimited</li>
             </ul>
           </td>
         </tr>

--- a/Sky Atlas/Sky Atlas.html
+++ b/Sky Atlas/Sky Atlas.html
@@ -28829,6 +28829,38 @@
         </tr>
         <tr>
           <td>
+            <dfn>Spark Savings V2</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The Ethereum Mainnet Instances Directory of the Spark Savings V2 with Active Status are stored herein.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Ethereum Mainnet - Spark Savings ETH Instance Configuration Document</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>This Instance's associated Instance Configuration Document is located at <dfn>Ethereum Mainnet - Spark Savings ETH Instance Configuration Document</dfn>.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Ethereum Mainnet - Spark Savings USDC Instance Configuration Document</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>This Instance's associated Instance Configuration Document is located at <dfn>Ethereum Mainnet - Spark Savings USDC Instance Configuration Document</dfn>.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Ethereum Mainnet - Spark Savings USDT Instance Configuration Document</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>This Instance's associated Instance Configuration Document is located at <dfn>Ethereum Mainnet - Spark Savings USDT Instance Configuration Document</dfn>.</td>
+        </tr>                
+        <tr>
+          <td>
             <dfn>Base Mainnet</dfn>
           </td>
           <td>Spark</td>
@@ -28922,6 +28954,46 @@
           <td>Spark</td>
           <td>Core</td>
           <td>This Instance's associated Instance Configuration Document is located at <dfn>Arbitrum - Aave USDC Instance Configuration Document</dfn>.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Avalanche</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain a Directory of all Instances on the Avalanche of the Allocation System Primitive with Instance status of Active.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Aave</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The Avalanche Instances Directory of the Aave Protocol with <code>Active</code> Status are stored herein.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Avalanche -  Aave v3 USDC Vault Instance Configuration Document</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>This Instance's associated Instance Configuration Document is located at <dfn>Avalanche -  Aave v3 USDC Vault Instance Configuration Document</dfn>.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Spark Savings V2</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The Avalanche Instances Directory of the Spark Savings V2 with Active Status are stored herein.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Avalanche - Spark Savings USDC Instance Configuration Document</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>This Instance's associated Instance Configuration Document is located at <dfn>Avalanche - Spark Savings USDC Instance Configuration Document</dfn>.</td>
         </tr>
         <tr>
           <td>
@@ -36259,6 +36331,608 @@
         </tr>
         <tr>
           <td>
+            <dfn>Spark Savings V2</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The Ethereum Mainnet Instances of the Spark Savings V2 with <code>Active</code> Status are stored herein.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Ethereum Mainnet - Spark Savings ETH Instance Configuration Document</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain the Instance Configuration Document for the Spark Savings ETH Instance.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>RRC Framework Full Implementation</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><strong><code>Covered</code></strong></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein define the parameters of the Spark Savings ETH Instance of the Allocation System Primitive.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Instance Identifiers</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein define the Instance identifiers</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Network</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>Ethereum Mainnet</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Target Protocol</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>Spark Savings Protocol</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Asset Supplied By SLL</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>ETH</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Token</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>spETH</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Contract Addresses</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein define the Instance contract addresses.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Token Address</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0xfE6eb3b609a7C8352A241f7F3A21CEA4e9209B8f</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Underlying Asset Address</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Spark Vault v2 Implementation</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0x1b992302652A92611DCd5090D1Cb388C6377f455</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Default admin</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0x3300f198988e4C9C63F75dF86De36421f06af8c4</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Setter</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0x2E1b01adABB8D4981863394bEa23a1263CBaeDfC</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Taker</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0x1601843c5E9bC251A3272907010AFa41Fa18347E</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Rate Limit IDs</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The specific <code>RateLimitID</code>(s) for this conduit's inflow and outflow will be specified in a future iteration of the Spark Artifact.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The current <code>maxAmount</code> and <code>slope</code> for this conduit's inflow/outflow are defined in the subdocuments herein.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Inflow Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The inflow rate limits are:
+            <ul>
+              <li><code>maxAmount</code>: unlimited</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Outflow Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The outflow rate limits are:
+            <ul>
+              <li><code>maxAmount</code>: Unlimited</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Risk Parameters Current Configuration</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The subdocuments herein define the current configuration of the risk parameters.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Spark Savings ETH Risk Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The Risk parameters are:
+            <ul>
+              <li>Supply cap: 10,000 WETH</li>
+              <li>Max yield: 5%</li>
+              <li>Current yield (at launch): 0%</li>
+            </ul>
+          </td>
+        </tr>        
+        <tr>
+          <td>
+            <dfn>Off-chain Operational Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain specific off-chain parameters for this Instance.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Instance-specific Operational Processes</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain operational procedures or monitoring requirements unique to this Instance that deviate from or otherwise supplement the general SLL processes.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Ethereum Mainnet - Spark Savings USDC Instance Configuration Document</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain the Instance Configuration Document for the Spark Savings USDC Instance.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>RRC Framework Full Implementation</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><strong><code>Covered</code></strong></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein define the parameters of the Spark Savings USDC Instance of the Allocation System Primitive.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Instance Identifiers</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein define the Instance identifiers</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Network</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>Ethereum Mainnet</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Target Protocol</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>Spark Savings Protocol</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Asset Supplied By SLL</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>USDC</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Token</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>spUSDC</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Contract Addresses</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein define the Instance contract addresses.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Token Address</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0x28B3a8fb53B741A8Fd78c0fb9A6B2393d896a43d</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Underlying Asset Address</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Spark Vault v2 Implementation</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0x1b992302652A92611DCd5090D1Cb388C6377f455</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Default admin</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0x3300f198988e4C9C63F75dF86De36421f06af8c4</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Setter</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0x2E1b01adABB8D4981863394bEa23a1263CBaeDfC</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Taker</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0x1601843c5E9bC251A3272907010AFa41Fa18347E</code></td>
+        </tr>        
+        <tr>
+          <td>
+            <dfn>Rate Limit IDs</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The specific <code>RateLimitID</code>(s) for this conduit's inflow and outflow will be specified in a future iteration of the Spark Artifact.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The current <code>maxAmount</code> and <code>slope</code> for this conduit's inflow/outflow are defined in the subdocuments herein.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Inflow Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The inflow rate limits are:
+            <ul>
+              <li><code>maxAmount</code>: unlimited</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Outflow Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The outflow rate limits are:
+            <ul>
+              <li><code>maxAmount</code>: Unlimited</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Risk Parameters Current Configuration</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The subdocuments herein define the current configuration of the risk parameters.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Spark Savings USDC Risk Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The Risk parameters are:
+            <ul>
+              <li>Supply cap: 50,000,000 USDC</li>
+              <li>Max yield: 10%</li>
+              <li>Current yield (at launch): 0%</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Off-chain Operational Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain specific off-chain parameters for this Instance.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Instance-specific Operational Processes</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain operational procedures or monitoring requirements unique to this Instance that deviate from or otherwise supplement the general SLL processes.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Ethereum Mainnet - Spark Savings USDT Instance Configuration Document</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain the Instance Configuration Document for the Spark Savings USDT Instance.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>RRC Framework Full Implementation</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><strong><code>Covered</code></strong></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein define the parameters of the Spark Savings USDT Instance of the Allocation System Primitive.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Instance Identifiers</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein define the Instance identifiers</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Network</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>Ethereum Mainnet</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Target Protocol</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>Spark Savings Protocol</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Asset Supplied By SLL</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>USDT</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Token</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>spUSDT</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Contract Addresses</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein define the Instance contract addresses.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Token Address</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0xe2e7a17dFf93280dec073C995595155283e3C372</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Underlying Asset Address</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0xdAC17F958D2ee523a2206206994597C13D831ec7</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Spark Vault v2 Implementation</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0x1b992302652A92611DCd5090D1Cb388C6377f455</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Default admin</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0x3300f198988e4C9C63F75dF86De36421f06af8c4</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Setter</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0x2E1b01adABB8D4981863394bEa23a1263CBaeDfC</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Taker</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0x1601843c5E9bC251A3272907010AFa41Fa18347E</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Rate Limit IDs</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The specific <code>RateLimitID</code>(s) for this conduit's inflow and outflow will be specified in a future iteration of the Spark Artifact.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The current <code>maxAmount</code> and <code>slope</code> for this conduit's inflow/outflow are defined in the subdocuments herein.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Inflow Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The inflow rate limits are:
+            <ul>
+              <li><code>maxAmount</code>: unlimited</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Outflow Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The outflow rate limits are:
+            <ul>
+              <li><code>maxAmount</code>: Unlimited</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Risk Parameters Current Configuration</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The subdocuments herein define the current configuration of the risk parameters.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Spark Savings USDT Risk Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The Risk parameters are:
+            <ul>
+              <li>Supply cap: 50,000,000 USDT</li>
+              <li>Max yield: 10%</li>
+              <li>Current yield (at launch): 0%</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Off-chain Operational Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain specific off-chain parameters for this Instance.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Instance-specific Operational Processes</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain operational procedures or monitoring requirements unique to this Instance that deviate from or otherwise supplement the general SLL processes.</td>
+        </tr>
+        <tr>
+          <td>
             <dfn>Base</dfn>
           </td>
           <td>Spark</td>
@@ -37221,6 +37895,212 @@
           <td>Spark</td>
           <td>Core</td>
           <td>The documents herein contain operational procedures or monitoring requirements unique to this Instance that deviate from or otherwise supplement the general SLL processes. For the general operational procedures applicable to all Aave-type instances. See <dfn>Aave Functions</dfn> and <dfn>Aave AToken Withdrawal Action</dfn>. For detailed example of the SLL interaction logic for depositing to and withdrawing from Aave see <dfn>Process Definition For Depositing</dfn> and <dfn>Process Definition For Withdrawing</dfn>.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Spark Savings V2</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The Avalanche Instances of the Spark Savings V2 with <code>Active</code> Status are stored herein.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Avalanche - Spark Savings USDC Instance Configuration Document</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain the Instance Configuration Document for the Spark Savings USDC Instance.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>RRC Framework Full Implementation</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><strong><code>Covered</code></strong></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein define the parameters of the Spark Savings USDC Instance of the Allocation System Primitive.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Instance Identifiers</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein define the Instance identifiers</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Network</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>Avalanche</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Target Protocol</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>Spark Savings Protocol</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Asset Supplied By SLL</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>USDC</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Token</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>spUSDC</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Contract Addresses</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein define the Instance contract addresses.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Token Address</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0x28B3a8fb53B741A8Fd78c0fb9A6B2393d896a43d</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Underlying Asset Address</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0xB97EF9Ef8734C71904D8002F8b6Bc66Dd9c48a6E</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Spark Vault v2 Implementation</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0xC2C0582D1cCe30449cF561C7b9C4D6d527547F12</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Default admin</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0x7566DEbC906C17338524A414343fA61BcA26A843</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Setter</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0x2E1b01adABB8D4981863394bEa23a1263CBaeDfC</code></td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Taker</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td><code>0xecE6B0E8a54c2f44e066fBb9234e7157B15b7FeC</code></td>
+        </tr>        
+        <tr>
+          <td>
+            <dfn>Rate Limit IDs</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The specific <code>RateLimitID</code>(s) for this conduit's inflow and outflow will be specified in a future iteration of the Spark Artifact.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The current <code>maxAmount</code> and <code>slope</code> for this conduit's inflow/outflow are defined in the subdocuments herein.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Inflow Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The inflow rate limits are:
+            <ul>
+              <li><code>maxAmount</code>: unlimited</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Outflow Rate Limits</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The outflow rate limits are:
+            <ul>
+              <li><code>maxAmount</code>: Unlimited</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Risk Parameters Current Configuration</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The subdocuments herein define the current configuration of the risk parameters.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Spark Savings USDC Risk Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The Risk parameters are:
+            <ul>
+              <li>Supply cap: 50,000,000 USDC</li>
+              <li>Max yield: 10%</li>
+              <li>Current yield (at launch): 0%</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Off-chain Operational Parameters</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain specific off-chain parameters for this Instance.</td>
+        </tr>
+        <tr>
+          <td>
+            <dfn>Instance-specific Operational Processes</dfn>
+          </td>
+          <td>Spark</td>
+          <td>Core</td>
+          <td>The documents herein contain operational procedures or monitoring requirements unique to this Instance that deviate from or otherwise supplement the general SLL processes.</td>
         </tr>
         <tr>
           <td>

--- a/Sky Atlas/Sky Atlas.html
+++ b/Sky Atlas/Sky Atlas.html
@@ -36521,7 +36521,7 @@
           <td>Core</td>
           <td>The Risk parameters are:
             <ul>
-              <li>Supply cap: 10,000 WETH</li>
+              <li>Supply cap: 50,000 WETH</li>
               <li>Max yield: 5%</li>
               <li>Current yield (at launch): 0%</li>
             </ul>
@@ -36743,7 +36743,7 @@
           <td>Core</td>
           <td>The Risk parameters are:
             <ul>
-              <li>Supply cap: 50,000,000 USDC</li>
+              <li>Supply cap: 250,000,000 USDC</li>
               <li>Max yield: 10%</li>
               <li>Current yield (at launch): 0%</li>
             </ul>
@@ -36965,7 +36965,7 @@
           <td>Core</td>
           <td>The Risk parameters are:
             <ul>
-              <li>Supply cap: 50,000,000 USDT</li>
+              <li>Supply cap: 250,000,000 USDT</li>
               <li>Max yield: 10%</li>
               <li>Current yield (at launch): 0%</li>
             </ul>
@@ -38160,7 +38160,7 @@
           <td>Core</td>
           <td>The Risk parameters are:
             <ul>
-              <li>Supply cap: 50,000,000 USDC</li>
+              <li>Supply cap: 150,000,000 USDC</li>
               <li>Max yield: 10%</li>
               <li>Current yield (at launch): 0%</li>
             </ul>


### PR DESCRIPTION
This PR aims to add a new section in the Spark Artifact that hosts the parameters of the Spark Savings Vaults.
The parameters used can be found in:

- https://forum.sky.money/t/october-2-2025-proposed-changes-to-spark-for-upcoming-spell/27191#p-104136-ethereum-spark-savings-launch-savings-v2-vaults-for-usdc-usdt-and-eth-7
- https://forum.sky.money/t/october-16-2025-proposed-changes-to-spark-for-upcoming-spell/27215#p-104208-avalanche-spark-liquidity-layer-onboard-avalanche-to-spark-liquidity-layer-4

The proposed Spark Savings changes have been added:
- https://forum.sky.money/t/october-30-2025-proposed-changes-to-spark-for-upcoming-spell/27309#p-104404-ethereum-spark-savings-increase-vault-deposit-caps-7
