### PR TITLE
Clarify grant rate decay formula in A.2.9.2.2.2.2.4

### DIFF
--- a/Sky Atlas/Sky Atlas.md
+++ b/Sky Atlas/Sky Atlas.md
@@ -11137,7 +11137,7 @@ The Base Rate will be dynamic and aligned with the SSR (Sky Savings Rate).
 
 ###### A.2.9.2.2.2.2.4 - Minimum Borrowing Threshold for Grant Eligibility [Core]  <!-- UUID: 23b21d6f-ad66-42ff-9e9f-c5bd5da6e8d4 -->
 
-Primes, including Spark and Grove, must each maintain a minimum borrowing of 1,000,000,000 USDS from Sky at all times to remain eligible for the full monthly reimbursement grant. If the amount borrowed falls below this threshold, the reimbursement grant will be proportionately slashed. This grant will cover the difference between the borrowing Base Rate and the T-bill rate. Spark and Grove can borrow amounts exceeding the 1,000,000,000 USDS limit at the prevailing Base Rate.
+Primes, including Spark and Grove, must each maintain a minimum borrowing of 1,000,000,000 USDS from Sky at all times to remain eligible for the full monthly reimbursement grant. The monthly reimbursement grant decays linearly over the 24-month subsidy window so that the borrower's effective borrowing rate equals `effective_rate(T) = TBill + (Base − TBill) * (T/24)`. Equivalently, the grant rate is `grant_rate(T) = (Base − TBill) * (1 − T/24)`, clamped at ≥ 0. This grant will cover the difference between the borrowing Base Rate and the T-bill rate. Spark and Grove can borrow amounts exceeding the 1,000,000,000 USDS limit at the prevailing Base Rate.
 
 ###### A.2.9.2.2.2.2.5 - Borrowing Above Subsidized Limit [Core]  <!-- UUID: c04dcedd-5e17-412f-8a71-55a76c29b80d -->
 


### PR DESCRIPTION
## Problem

A.2.9.2.2.2.2.4 (Minimum Borrowing Threshold for Grant Eligibility) currently reads like the grant always covers the full `(Base − TBill)` difference (i.e., a constant full subsidy → effective rate always = TBill). 

This conflicts with the ramping effective-rate formula in A.2.9.2.2.2.2.2 (Borrow Rate Mechanism).

## Solution

Keep the effective-rate formula exactly as written in A.2.9.2.2.2.2.2, and define the grant so that it produces that effective rate:

**Grant (reimbursement) rate:**

`grant_rate(T) = Base − effective_rate(T) = (Base − TBill) * (1 − T/24)`

(clamped at ≥ 0 so no negative grants if Base ≤ TBill)

This makes explicit that the grant decays linearly from `(Base − TBill)` at T=0 down to 0 at T=24, exactly matching the effective-rate ramp.

## Proposed Text Change

In A.2.9.2.2.2.2.4, replace:
> "This grant will cover the difference between the borrowing Base Rate and the T-bill rate."

With:
> "The monthly reimbursement grant decays linearly over the 24-month subsidy window so that the borrower's effective borrowing rate equals `effective_rate(T) = TBill + (Base − TBill) * (T/24)`. Equivalently, the grant rate is `grant_rate(T) = (Base − TBill) * (1 − T/24)`, clamped at ≥ 0."

## Example (Sanity Check)

With `Base = 8%` and `TBill = 4%`:

| Month (T) | Grant Rate | Effective Rate |
|-----------|------------|----------------|
| T=0       | 4%         | 4%             |
| T=12      | 2%         | 6%             |
| T=24      | 0%         | 8%             |
