### PR TITLE
Atlas Validator GitHub action: fix permission error by removing the auto-comment feature

### DIFF
--- a/.github/workflows/validate-atlas.yml
+++ b/.github/workflows/validate-atlas.yml
@@ -8,44 +8,12 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write # Required for posting comments
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Validate Atlas Markdown
-        id: validate
         uses: Atlas-Axis/atlas-validator@main
         with:
           file_path: "Sky Atlas/Sky Atlas.md"
-        continue-on-error: true
-
-      - name: Comment on PR
-        if: steps.validate.outputs.has_errors == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-
-            // Read the validation summary file
-            let summary = '';
-            try {
-              summary = fs.readFileSync('validation-summary.md', 'utf8');
-            } catch (error) {
-              summary = '## ⚠️ Validation Summary Not Available\n\nUnable to read validation results.';
-            }
-
-            // Post comment with validation errors
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: summary
-            });
-
-      - name: Fail if validation errors
-        if: steps.validate.outputs.has_errors == 'true'
-        run: exit 1


### PR DESCRIPTION
Problem:
- PRs from external forks failed with "Resource not accessible by integration" (403) when trying to post PR comments, because `pull_request` trigger has read-only permissions for fork PRs
- Initial fix using `pull_request_target` introduced security concerns flagged by GitHub Copilot, and had complex setup requirements (special checkout ref, extra permissions)

Solution:
- Dismissed `pull_request_target` approach entirely
- Simplified to standard `pull_request` trigger which works for all PRs, including PRs coming from forks
- Removed PR comment functionality in favor of GitHub's native features:
  - Inline annotations on Files Changed tab
  - Job Summary with detailed validation report
  - Check pass/fail status

Benefits:
- No security concerns
- Works identically for internal branches and external forks
- No special permissions or configuration needed
- Simpler setup