### PR TITLE
Always run the `validate` check to satisfy branch protection rules

### DIFF
--- a/.github/workflows/validate-atlas.yml
+++ b/.github/workflows/validate-atlas.yml
@@ -2,8 +2,6 @@ name: Validate Atlas on Pull Request
 
 on:
   pull_request:
-    paths:
-      - "Sky Atlas/Sky Atlas.md"
 
 jobs:
   validate:


### PR DESCRIPTION
Remove unnecessary paths section from `pull_request` trigger to satisfy the branch protection rules (`validate` check must pass) - the Atlas validator runs on every PR, even when the Atlas markdown file doesn't change