### PR TITLE
add Grove Genesis Capital

### DIFF
--- a/Sky Atlas/Sky Atlas.md
+++ b/Sky Atlas/Sky Atlas.md
@@ -16977,6 +16977,7 @@ The Genesis Capital of an Agent is the lesser of (1) the Eligible Genesis Capita
 The amount of capital contributed by Sky to Agents is:
 
 - Spark - 25,000,000 USDS
+- Grove - 25,000,000 USDS
 - Obex - 21,000,000 USDS
 - Skybase - 15,000,000 USDS
 - Core Council Executor Agent 1 - 25,000,000 USDS


### PR DESCRIPTION
Adds Grove Genesis Capital transferred in the [2026-04-09 spell](https://vote.sky.money/executive/template-executive-vote-launch-avalanche-skylink-update-staking-rewards-grove-genesis-capital-transfer-safe-harbor-update-prime-agent-proxy-spells-april-9-2026)