### PR TITLE
Update USDS Demand Subsidies Multisig Signers to 3/5

### DIFF
--- a/content/A/6/1/1/4/3/4/2/2/document.md
+++ b/content/A/6/1/1/4/3/4/2/2/document.md
@@ -9,4 +9,4 @@ childType: sections_and_primary_docs
 
 ###### A.6.1.1.4.3.4.2.2 - Required Number of Signers [Core]
 
-The USDS Demand Subsidies Multisig currently has a 2/3 signing requirement.
+The USDS Demand Subsidies Multisig currently has a 3/5 signing requirement.

--- a/content/A/6/1/1/4/3/4/2/3/document.md
+++ b/content/A/6/1/1/4/3/4/2/3/document.md
@@ -11,5 +11,5 @@ childType: sections_and_primary_docs
 
 The USDS Demand Subsidies Multisig has the following signers:
 
-- Soter Labs: 2 signers
+- Soter Labs: 4 signers
 - Skybase Foundation: 1 signer

--- a/content/A/6/1/1/4/3/4/2/5/document.md
+++ b/content/A/6/1/1/4/3/4/2/5/document.md
@@ -9,4 +9,4 @@ childType: sections_and_primary_docs
 
 ###### A.6.1.1.4.3.4.2.5 - Modification [Core]
 
-Operational GovOps Soter Labs can change the signers of the USDS Demand Subsidies Multisig at any time, so long as there are at least two (2) signers from Soter Labs and one (1) signer from Skybase Foundation, and at least two-thirds of signers are required to execute transactions.
+Operational GovOps Soter Labs can change the signers of the USDS Demand Subsidies Multisig at any time, so long as there are at least four (4) signers from Soter Labs and one (1) signer from Skybase Foundation, and at least three-fifths of signers are required to execute transactions.

--- a/content/A/6/1/1/4/3/4/2/document.md
+++ b/content/A/6/1/1/4/3/4/2/document.md
@@ -9,4 +9,4 @@ childType: sections_and_primary_docs
 
 ###### A.6.1.1.4.3.4.2 - USDS Demand Subsidies Multisig [Core]
 
-The USDS Demand Subsidies Multisig is controlled by two (2) signers from Operational GovOps Soter Labs and one (1) signer from Skybase Foundation.
+The USDS Demand Subsidies Multisig is controlled by four (4) signers from Operational GovOps Soter Labs and one (1) signer from Skybase Foundation.


### PR DESCRIPTION
Updates the USDS Demand Subsidies Multisig (A.6.1.1.4.3.4.2):

- Soter Labs signers: 2 → 4
- Signing requirement: 2/3 → 3/5
- Modification clause updated to require at least four (4) Soter Labs signers and a three-fifths threshold

Decomposed `content/` source only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)