### PR TITLE
Add Skybase to Current Authorized Forum Accounts

### DIFF
--- a/content/A.2 - The-Support-Scope.md
+++ b/content/A.2 - The-Support-Scope.md
@@ -4772,6 +4772,7 @@ The Active Data is updated as follows:
 | JanSky | Core Facilitator | JanSky-Team | JanSky, ldr |
 | Rune | N/A | rune | N/A |
 | Amatsu | Operational Executor Agent | Amatsu_OEA | SoterLabs, Endgame-Edge (and their authorized representatives) |
+| Skybase | Prime Agent | Ekliptyka | N/A |
 
 ##### A.2.7.1.1.2 - Chatroom [Core]  <!-- UUID: a596136b-a805-420b-be77-bf249e41ada4 -->
 


### PR DESCRIPTION
## Summary

Registers Skybase's authorized Sky Forum account (Ekliptyka) in A.2.7.1.1.1.1.4.0.6.1 - Current Authorized Forum Accounts. Skybase is listed with the role Prime Agent, consistent with the other Stars in the table.

## Change

Single-line addition to the Current Authorized Forum Accounts table in `content/A.2 - The-Support-Scope.md`:

| Entity Name | Role | Entity Handle | Handles of Authorized Representatives |
|---|---|---|---|
| Skybase | Prime Agent | Ekliptyka | N/A |

## Process

Enacted via the Direct Edit process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
