### PR TITLE
Atlas Edit Proposal — 2026-09-07

### DIFF
--- a/content/A.1 - The-Governance-Scope.md
+++ b/content/A.1 - The-Governance-Scope.md
@@ -2842,7 +2842,7 @@ The items included in the Prime Agent's Forum posts must undergo a financial ris
 
 Under the Sky Governance path, the financial risk assessment is conducted by the [A.1.8.1.1 - Core Council Risk Advisor](d80c8f64-b3f6-430d-bf62-8e50a3783e73). The assessment must be posted on the Forum thread by Thursday, 16:00 UTC of week 1.
 
-Under the Independent Governance path, the financial risk assessment is conducted by an independent risk assessor designated by the Prime Agent.
+Under the Independent Governance path, the financial risk assessment is conducted by an independent risk assessor designated by the Prime Agent. If the Prime Agent has no designated independent risk assessor, the financial risk assessment is conducted by the Core Council Risk Advisor.
 
 ###### A.1.10.2.3.2.2.3.2.4 - Atlas Edit Proposal Drafting And Submission [Core]  <!-- UUID: 0c442b02-f6c9-4bb2-af7f-f73ee31d9b1f -->
 
@@ -2910,7 +2910,7 @@ The execution of Agent Spells is described in the subdocuments herein. Two metho
 
 ###### A.1.10.2.3.2.3.1 - Execution Through StarGuard [Core]  <!-- UUID: 78ec918d-cd9e-4326-bfa9-ab338e658a8b -->
 
-When the execution through the StarGuard method is used, the Agent Spells are whitelisted in Sky Core Spells and later executed using the StarGuard module. The Sky Core Spell includes a whitelist of approved Agent Spells, which allows them to be executed via separate transactions. This enhances resilience and scalability, ensuring robust handling of payloads from multiple active Agents while minimizing risks to Sky Core.
+When the execution through the StarGuard method is used, the Agent Spells are whitelisted in Sky Core Spells and later executed using the StarGuard contract. The Sky Core Spell includes a whitelist of approved Agent Spells, which allows them to be executed via separate transactions. This enhances resilience and scalability, ensuring robust handling of payloads from multiple active Agents while minimizing risks to Sky Core.
 
 ###### A.1.10.2.3.2.3.1.1 - StarGuard [Core]  <!-- UUID: e5cbb61a-82c3-4fce-b6f2-191911d5c155 -->
 

--- a/content/A.2 - The-Support-Scope.md
+++ b/content/A.2 - The-Support-Scope.md
@@ -4781,21 +4781,21 @@ The documents herein define interim exceptions to the process definition for the
 
 ###### A.2.4.1.2.1.5.1 - Scope Of July / August 2025 Monthly Settlement Cycle [Core]  <!-- UUID: bfc3548d-5ad1-4327-a54a-ddd4549c5fdc -->
 
-The initial Monthly Settlement Cycle conducted in September 2025 will be for the two month period from July 1, 2025 to August 31, 2025.
+The initial Monthly Settlement Cycle conducted in September 2025 was for the two (2) month period from July 1, 2025 to August 31, 2025.
 
 ###### A.2.4.1.2.1.5.2 - Process For July / August 2025 Monthly Settlement Cycle [Core]  <!-- UUID: 146d3d9c-7f8a-4dc4-b6b3-349bab4279bb -->
 
-For the initial Monthly Settlement Cycle conducted in September 2025, the Initial Calculation prepared by Operational Executor Agent Amatsu will only include calculations related to Demand Side Stablecoin Primitives (see [A.2.2.9 - Demand Side Stablecoin Primitives](26415305-432d-423b-9553-3f325279712d)). The Independent Calculation prepared by the Core Council Risk Advisor on behalf of the Core Council will be prepared normally. The calculations related to Demand Side Stablecoin Primitives will be subject to the normal resolution process defined in [A.2.4.1.2.1.2 - Final Calculation By Core GovOps](9de89bf3-9051-44f1-9ec0-d362ee4d4b38). For all other calculations, the amounts in the Independent Calculation will be treated as Agreed Amounts. The Initial Calculation and the Independent Calculation will be posted to the Sky Forum by September 10, 2025.
+For the initial Monthly Settlement Cycle conducted in September 2025, the Initial Calculation prepared by Operational Executor Agent Amatsu was required to include only calculations related to Demand Side Stablecoin Primitives (see [A.2.2.9 - Demand Side Stablecoin Primitives](26415305-432d-423b-9553-3f325279712d)). The Independent Calculation prepared by the Core Council Risk Advisor on behalf of the Core Council was required to be prepared normally. The calculations related to Demand Side Stablecoin Primitives were subject to the normal resolution process defined in [A.2.4.1.2.1.2 - Final Calculation By Core GovOps](9de89bf3-9051-44f1-9ec0-d362ee4d4b38). For all other calculations, the amounts in the Independent Calculation were treated as Agreed Amounts. The Initial Calculation and the Independent Calculation were required to be posted to the Sky Forum by September 10, 2025.
 
 ###### A.2.4.1.2.1.5.3 - Process For September 2025 Monthly Settlement Cycle [Core]  <!-- UUID: 8e8ff62f-c6c5-4094-afd1-2cedcf482df6 -->
 
-For the Monthly Settlement Cycle conducted in October 2025, the Initial Calculation prepared by Operational Executor Agent Amatsu will only include calculations related to Spark. The Independent Calculation prepared by the Core Council Risk Advisor on behalf of the Core Council will be prepared normally. The calculations related to Spark will be subject to the normal resolution process defined in [A.2.4.1.2.1.2 - Final Calculation By Core GovOps](9de89bf3-9051-44f1-9ec0-d362ee4d4b38). For all other calculations, the amounts in the Independent Calculation will be treated as Agreed Amounts.
+For the Monthly Settlement Cycle conducted in October 2025, the Initial Calculation prepared by Operational Executor Agent Amatsu included only calculations related to Spark. The Independent Calculation prepared by the Core Council Risk Advisor on behalf of the Core Council was prepared normally. The calculations related to Spark were subject to the normal resolution process defined in [A.2.4.1.2.1.2 - Final Calculation By Core GovOps](9de89bf3-9051-44f1-9ec0-d362ee4d4b38). For all other calculations, the amounts in the Independent Calculation were treated as Agreed Amounts.
 
 ###### A.2.4.1.2.1.5.4 - Process For November / December 2025 Monthly Settlement Cycle [Core]  <!-- UUID: 5aa66a15-d59c-4f66-9d80-96583698f24d -->
 
-There will be no Monthly Settlement Cycle conducted in December 2025. Instead, the Monthly Settlement Cycle conducted in January 2026 will be for the two-month period from November 1, 2025 to December 31, 2025.
+There was no Monthly Settlement Cycle conducted in December 2025. Instead, the Monthly Settlement Cycle conducted in January 2026 was for the two (2) month period from November 1, 2025 to December 31, 2025.
 
-For the Monthly Settlement Cycle conducted in January 2026, the Independent Calculation prepared by the Core Council Risk Advisor on behalf of the Core Council will only include calculations related to Spark. The Initial Calculation prepared by Operational Executor Agent Amatsu will be prepared normally. The calculations related to Spark will be subject to the normal resolution process defined in [A.2.4.1.2.1.2 - Final Calculation By Core GovOps](9de89bf3-9051-44f1-9ec0-d362ee4d4b38). For all other calculations, the amounts in the Initial Calculation will be treated as Agreed Amounts.
+For the Monthly Settlement Cycle conducted in January 2026, the Independent Calculation prepared by the Core Council Risk Advisor on behalf of the Core Council was required to include only calculations related to Spark. The Initial Calculation prepared by Operational Executor Agent Amatsu was required to be prepared normally. The calculations related to Spark were subject to the normal resolution process defined in [A.2.4.1.2.1.2 - Final Calculation By Core GovOps](9de89bf3-9051-44f1-9ec0-d362ee4d4b38). For all other calculations, the amounts in the Initial Calculation were treated as Agreed Amounts.
 
 ##### A.2.4.1.2.2 - Implementation Stages [Core]  <!-- UUID: cf1d76c1-fc9f-499d-866f-265276e421f0 -->
 
@@ -4807,7 +4807,7 @@ The documents herein define Stage 1 of the implementation of the Monthly Settlem
 
 ###### A.2.4.1.2.2.1.1 - Stage 1 Simplified Profit And Loss Calculation [Core]  <!-- UUID: 65bd404f-0fd4-4ae9-9860-2c6e37731fef -->
 
-In Stage 1 of the implementation of the Monthly Settlement Cycle, the net amount due from each Prime to Sky will be calculated using a Simplified Profit And Loss Calculation as specified in the documents herein.
+In Stage 1 of the implementation of the Monthly Settlement Cycle, the net amount due from each Prime to Sky is calculated using a Simplified Profit And Loss Calculation as specified in the documents herein.
 
 ###### A.2.4.1.2.2.1.1.1 - Amount Due From Sky To Primes With Respect To Demand Side Primitives And Agent Rate [Core]  <!-- UUID: 33d1b516-d347-4d44-9af6-95f25e8a8d8c -->
 
@@ -4895,7 +4895,7 @@ Spark pays the Agent Credit Line Borrow Rate with respect to funds borrowed by S
 
 ###### A.2.4.1.2.2.1.2 - Stage 1 Timing [Core]  <!-- UUID: ff3aa296-34eb-4783-904f-4510fa0c6c37 -->
 
-Stage 1 is currently expected to be implemented in the August 21, 2025 Executive Vote for the period from July 1, 2025 to July 31, 2025.
+Stage 1 applied to the period from July 1, 2025 through October 31, 2025. Stage 1 was first implemented in the September 18, 2025 Executive Vote.
 
 ###### A.2.4.1.2.2.1.3 - Stage 1 Actions [Core]  <!-- UUID: f87c520a-3324-46a7-ac4e-9c7de2a2af0a -->
 
@@ -4919,7 +4919,7 @@ In Stage 2 of the implementation of the Monthly Settlement Cycle, the net amount
 
 ###### A.2.4.1.2.2.2.2 - Stage 2 Timing [Core]  <!-- UUID: ceb3c433-d73f-4c58-bac9-e79b44e66fcf -->
 
-Stage 2 will be implemented in the December 2025 Monthly Settlement Cycle for the period from November 1, 2025 to November 30, 2025. If there is no December 2025 Monthly Settlement Cycle, then Stage 2 will be implemented in the January 2026 Monthly Settlement Cycle for the period from November 1, 2025 to December 31, 2025.
+Stage 2 applies to the period from November 1, 2025 onward. Stage 2 was first implemented in the Monthly Settlement Cycle conducted in January 2026.
 
 ###### A.2.4.1.2.2.2.3 - Stage 2 Actions [Core]  <!-- UUID: b8c86fb3-2ba4-4c53-a509-81d022dffd20 -->
 
@@ -5517,11 +5517,11 @@ The standard Distribution Reward rate is set at 0.2%.
 
 ###### A.2.8.2.2.2.3.2 - 2025 Bonus [Core]  <!-- UUID: 7ca440d3-03fb-4fba-81a8-d2118dc47aa6 -->
 
-An additional 0.4% Distribution Reward bonus will apply during the calendar year 2025 (ending December 31, 2025). This bonus is strictly limited to the Prime and does not extend to the Prime Foundation. The bonus is subject to the limitation specified in [A.2.8.2.2.2.3.2.1 - Bonus Limitation](6996e6c9-b936-4680-855f-b9717572082d).
+An additional 0.4% Distribution Reward bonus applied during the calendar year 2025 (ending December 31, 2025). This bonus was strictly limited to the Prime and did not extend to the Prime Foundation. The bonus was subject to the limitation specified in [A.2.8.2.2.2.3.2.1 - Bonus Limitation](6996e6c9-b936-4680-855f-b9717572082d).
 
 ###### A.2.8.2.2.2.3.2.1 - Bonus Limitation [Core]  <!-- UUID: 6996e6c9-b936-4680-855f-b9717572082d -->
 
-USDS and sUSDS balances held by the Prime itself are not eligible for the Distribution Reward bonus specified in [A.2.8.2.2.2.3.2 - 2025 Bonus](7ca440d3-03fb-4fba-81a8-d2118dc47aa6).
+USDS and sUSDS balances held by the Prime itself were not eligible for the Distribution Reward bonus specified in [A.2.8.2.2.2.3.2 - 2025 Bonus](7ca440d3-03fb-4fba-81a8-d2118dc47aa6).
 
 ###### A.2.8.2.2.2.3.3 - Sky Spread [Core]  <!-- UUID: 5e3e9338-221a-461a-96f9-01e0665ab6a4 -->
 
@@ -6244,7 +6244,7 @@ where sub-periods are defined by any change to the USDS deposited in the Chronic
 
 ###### A.2.8.2.10.2.1.5 - Retroactive Compensation [Core]  <!-- UUID: e19ba00b-8509-4cf1-b9af-20f16e9683f8 -->
 
-Grove is entitled to retroactive compensation for the period from July 24, 2025 to March 31, 2026, to be settled in the April 2026 Monthly Settlement Cycle.
+Grove was entitled to retroactive compensation for the period from July 24, 2025 to March 31, 2026, which was settled in the April 2026 Monthly Settlement Cycle.
 
 ###### A.2.8.2.10.2.2 - Prime Revenue Credit [Core]  <!-- UUID: 03bec0ca-5667-40ae-ac54-62ce1a0c66ea -->
 
@@ -6445,7 +6445,7 @@ Geographical coverage is worldwide.
 
 ###### A.2.9.1.1.1.3.5 - Resilience Fund Policy Effective Date [Core]  <!-- UUID: 9de7d51b-32f3-4746-b97d-9eb75a189cb6 -->
 
-A Beneficiary’s eligibility for coverage under this Artifact will start after ratification of MIP106: 2023-03-27. ("Effective Date") and expire twenty-four (24) months after cessation of their role as a Beneficiary.
+Coverage under this Artifact is available following the ratification of MIP106 on 2023-03-27 ("Effective Date"). A Beneficiary's eligibility for coverage expires twenty-four (24) months after cessation of their role as a Beneficiary.
 
 ###### A.2.9.1.1.1.3.6 - Resilience Fund Policy Base Of Coverage [Core]  <!-- UUID: 9204cca6-3e91-4a34-b8be-fa6135d41f24 -->
 

--- a/content/A.3 - The-Stability-Scope.md
+++ b/content/A.3 - The-Stability-Scope.md
@@ -56,7 +56,7 @@ This Section defines the Core Stability Parameters.
 
 #### A.3.1.2.1 - Base Rate [Core]  <!-- UUID: 228f9955-6bba-4252-a101-5529e7a300b9 -->
 
-The Base Rate is the key interest rate in the system. It defines all other rates by various spreads. It is expressed as an annual percentage yield.
+The Base Rate is the key interest rate in the system. It defines all other rates by various spreads. It is expressed as an annual percentage rate as specified in [A.3.1.2.7 - Rate Conventions](154c3b5d-7a87-4dae-85f3-7d26deab9a31).
 
 ##### A.3.1.2.1.0.3.1 - Spreads - Element Annotation [Annotation]  <!-- UUID: e7be875c-fa61-42af-8986-ec22aceab0e8 -->
 
@@ -83,15 +83,17 @@ The Stability Parameter Bounded External Access Module parameters for the Sky Sa
 - `step` - 400 basis points,
 - `tau` - Globally defined in [A.3.7.1.3.1.4.1 - Tau Current Value](dd9472e5-9796-4aff-a2b1-7a847e008c9b).
 
+These basis-point values are expressed as annual percentage yields, as specified in [A.3.1.2.7 - Rate Conventions](154c3b5d-7a87-4dae-85f3-7d26deab9a31).
+
 ##### A.3.1.2.2.3 - Sky Savings Rate Current Value [Core]  <!-- UUID: aff1868f-66aa-4252-851f-9343567a52eb -->
 
-The current value of the Sky Savings Rate can be obtained by calling the `ssr()` function on the sUSDS contract located on the Ethereum Mainnet at `0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD`.
+The current value of the Sky Savings Rate can be obtained by calling the `ssr()` function on the sUSDS contract located on the Ethereum Mainnet at `0xa3931d71877C0E7a3148CB7Eb4463524FEc27fbD`. The value returned is the per-second compounding factor; the Sky Savings Rate is the annual percentage rate, as specified in [A.3.1.2.7 - Rate Conventions](154c3b5d-7a87-4dae-85f3-7d26deab9a31), whose accrual over one (1) year is equivalent to compounding that factor every second.
 
-The `ssr()` function returns a per-second compounding rate in RAY precision (10^27). The equivalent annualized rate, compounded over a 365-day year (31,536,000 seconds), is given by the formula:
+The `ssr()` function returns a per-second compounding rate in RAY precision (10^27). The Sky Savings Rate expressed as an annual percentage rate is given by the formula:
 
-`annualized rate = (ssr() / 1E27)^31536000 - 1`
+`annual percentage rate = 12 * ((ssr() / 1E27)^2628000 - 1)`
 
-The result is a decimal rate (e.g., 0.0365 represents 3.65% per year).
+where 2,628,000 is the number of seconds in one (1) month of a 365-day year. The result is a decimal rate (e.g., 0.0346 represents 3.46% per year); the annual percentage yield equivalent is obtained by the conversion specified in [A.3.1.2.7 - Rate Conventions](154c3b5d-7a87-4dae-85f3-7d26deab9a31).
 
 #### A.3.1.2.3 - Agent Rate [Core]  <!-- UUID: 012c953b-c522-4ea3-939b-3282af4e1d7e -->
 
@@ -144,9 +146,11 @@ The Stability Parameter Bounded External Access Module parameters for the Dai Sa
 - `step` - 400 basis points,
 - `tau` - Globally defined in [A.3.7.1.3.1.4.1 - Tau Current Value](dd9472e5-9796-4aff-a2b1-7a847e008c9b).
 
+These basis-point values are expressed as annual percentage yields, as specified in [A.3.1.2.7 - Rate Conventions](154c3b5d-7a87-4dae-85f3-7d26deab9a31).
+
 #### A.3.1.2.5 - Agent Credit Line Borrow Rate [Core]  <!-- UUID: 6b2b7302-e63b-457e-afeb-daab5ca7a7de -->
 
-The Agent Credit Line Borrow Rate is the annual percentage yield that Agents must pay to Sky Core to receive USDS liquidity into their respective vaults.
+The Agent Credit Line Borrow Rate is the annual percentage rate that Agents must pay to Sky Core to receive USDS liquidity into their respective vaults.
 
 ##### A.3.1.2.5.1 - Relationship To Base Rate [Core]  <!-- UUID: 4659cbf0-78c2-469b-8432-883e5c931dd1 -->
 
@@ -174,9 +178,13 @@ The Sky Spread is a margin Sky retains for facilitating the ecosystem’s financ
 
 #### A.3.1.2.7 - Rate Conventions [Core]  <!-- UUID: 154c3b5d-7a87-4dae-85f3-7d26deab9a31 -->
 
-Unless otherwise specified, all rates defined in the Atlas are expressed as annual percentage yields.
+Unless otherwise specified, all rates defined in the Atlas are expressed as annual percentage rates with a monthly compounding frequency. The annual percentage yield equivalent of a rate is given by the formula:
 
-A spread between two rates defined in the Atlas is the arithmetic difference between their annual percentage yields. Where the Atlas specifies one rate as another rate plus or minus a spread, that spread is added to or subtracted from the annual percentage yield directly, without conversion.
+`annual percentage yield = (1 + annual percentage rate / 12)^12 - 1`
+
+A spread between two rates defined in the Atlas is the arithmetic difference between their annual percentage rates. Where the Atlas specifies one rate as another rate plus or minus a spread, that spread is added to or subtracted from the annual percentage rate directly. A rate specified as an annual percentage yield is first converted to its equivalent annual percentage rate before any such arithmetic is performed.
+
+Rates may be displayed as their annual percentage yield equivalents in user-facing interfaces and communications. Where a rate is implemented by a smart contract that compounds at a different frequency, the technical parameter is set such that the accrual produced by the smart contract over one (1) year equals the accrual of the stated rate. Basis-point rate parameters, and the bounds on them, set through Bounded External Access Modules are expressed as annual percentage yields, matching the conversion enforced by the module contracts. A rate applied through periodic payments that are not added to an accruing balance is applied at the annual percentage rate divided by the number of payment periods in each year.
 
 ### A.3.1.0.3.1 - Methodologies - Element Annotation [Annotation]  <!-- UUID: 2f658a82-a8d2-4bd1-be5c-906e4733400d -->
 
@@ -3541,7 +3549,7 @@ The Stability Parameter Bounded External Access Module (SP-BEAM) enables designa
 
 ##### A.3.7.1.3.1 - Definitions [Core]  <!-- UUID: b113ca06-9a25-4abf-81f1-53f419ffe2d2 -->
 
-The documents herein define the parameters of the Stability Parameter Bounded External Access Module.
+The documents herein define the parameters of the Stability Parameter Bounded External Access Module. The basis-point values of the `min`, `max`, and `step` parameters are expressed as annual percentage yields, as specified in [A.3.1.2.7 - Rate Conventions](154c3b5d-7a87-4dae-85f3-7d26deab9a31).
 
 ###### A.3.7.1.3.1.1 - Min Definition [Core]  <!-- UUID: 1896350c-5f87-4be5-b32f-f1114dc2c271 -->
 

--- a/content/A.4 - The-Protocol-Scope.md
+++ b/content/A.4 - The-Protocol-Scope.md
@@ -826,7 +826,7 @@ The stUSDS Bounded External Access Module (stUSDS BEAM) enables designated, Gove
 
 ###### A.4.4.1.3.8.1 - Definitions [Core]  <!-- UUID: 2875f146-08b2-4b83-84ed-282af9379762 -->
 
-The documents herein define the parameters of the stUSDS BEAM.
+The documents herein define the parameters of the stUSDS BEAM. The basis-point values of the `min`, `max`, and `step` parameters are expressed as annual percentage yields, as specified in [A.3.1.2.7 - Rate Conventions](154c3b5d-7a87-4dae-85f3-7d26deab9a31).
 
 ###### A.4.4.1.3.8.1.1 - Min Definition [Core]  <!-- UUID: f1ed4794-7642-4ce4-ae80-c5f4e2ec0eed -->
 
@@ -1247,7 +1247,7 @@ The SubProxyMethods contract does not itself restrict which destination is speci
 
 A call to the SubProxyMethods contract is included in the Sky Core Spell and executed as specified in [A.1.10.2.4.13 - Spell Execution Process And Retro (Step 13)](761cd866-17a9-47f5-8ae6-ab1788371be1).
 
-Unlike a standard Agent Spell, it is not executed or whitelisted through the Agent's StarGuard module.
+Unlike a standard Agent Spell, it is not executed or whitelisted through the Agent's StarGuard contract.
 
 ##### A.4.6.2.1.4 - Governance Process [Core]  <!-- UUID: 813a123a-d6e1-4ef2-bc55-716b50732721 -->
 

--- a/content/A.6.1.1.3 - Keel.md
+++ b/content/A.6.1.1.3 - Keel.md
@@ -2458,8 +2458,11 @@ The documents herein define roles (Admin, Relayer, ALM Controller and Freezer) a
 
 The admin role (`DEFAULT_ADMIN_ROLE`) is the role that can grant and revoke any role, including itself and all other roles defined in the contract. The admin role is also used for general admin functions in all contracts. This role is fully controlled by Sky Governance via the Keel Proxy.
 
-`constructor(address admin) {
-_grantRole(DEFAULT_ADMIN_ROLE, admin);`
+```solidity
+constructor(address admin_) {
+    _grantRole(DEFAULT_ADMIN_ROLE, admin_);
+}
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.1.2 - Relayer Role [Core]  <!-- UUID: 1b64d5b8-ea7d-408e-a409-3e9e72989396 -->
 
@@ -2489,7 +2492,7 @@ The documents herein define the operations performed by the admin role (see [A.6
 
 The documents herein define the steps for an admin to specify which address should receive newly minted tokens on a particular destination domain.
 
-###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.1.1.1 - Call setMintRecipient Function [Core]  <!-- UUID: 0d2d22cf-1ee4-44ee-8e10-95f516da51a9 -->
+###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.1.1.1 - setMintRecipient Function [Core]  <!-- UUID: 0d2d22cf-1ee4-44ee-8e10-95f516da51a9 -->
 
 Only an operator with the admin role is able to set the mint recipient for a destination domain. To do so, they must call the `setMintRecipient` function on the Controller contract on mainnet providing the destination domain and the mint recipient address. Calling this function will carry out the following actions:
 
@@ -2497,15 +2500,17 @@ Only an operator with the admin role is able to set the mint recipient for a des
 - The contract will set the selected mint recipient for the specified destination domain.
 - The contract will emit a `MintRecipientSet` event to the blockchain logs.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function setMintRecipient(uint32 destinationDomain, bytes32 mintRecipient) external`
+```solidity
+function setMintRecipient(uint32 destinationDomain, bytes32 mintRecipient) external
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.1.2 - Set LayerZero Recipient [Core]  <!-- UUID: 753bcc77-e4a6-438b-942c-bf2b4ef908be -->
 
 The documents herein define the steps for an admin to specify which address should receive LayerZero messages on a particular destination endpoint.
 
-###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.1.2.1 - Call setLayerZeroRecipient Function [Core]  <!-- UUID: aceb66dc-7349-4d49-a893-7ed417e83797 -->
+###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.1.2.1 - setLayerZeroRecipient Function [Core]  <!-- UUID: aceb66dc-7349-4d49-a893-7ed417e83797 -->
 
 Only an operator with the admin role is able to set the LayerZero recipient for a destination endpoint. To do so, they must call the `setLayerZeroRecipient` function on the Controller contract on mainnet, providing the destination endpoint ID and the recipient address. Calling this function will carry out the following actions:
 
@@ -2513,15 +2518,17 @@ Only an operator with the admin role is able to set the LayerZero recipient for 
 - The contract will set the selected LayerZero recipient for the specified destination endpoint.
 - The contract will emit a `LayerZeroRecipientSet` event to the blockchain logs.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function setLayerZeroRecipient(uint32 destinationEndpointId, bytes32 layerZeroRecipient) external`
+```solidity
+function setLayerZeroRecipient(uint32 destinationEndpointId, bytes32 layerZeroRecipient) external
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.1.3 - Set Maximum Slippage [Core]  <!-- UUID: 323bb906-f37c-470d-8124-b133a050ffa6 -->
 
 The documents herein define the steps for an admin to set the maximum allowed slippage for a specific pool.
 
-###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.1.3.1 - Set The Maximum Slippage Function [Core]  <!-- UUID: 8838da61-5edf-4ad5-b910-d4536aecd822 -->
+###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.1.3.1 - setMaxSlippage Function [Core]  <!-- UUID: 8838da61-5edf-4ad5-b910-d4536aecd822 -->
 
 Only an operator with the admin role is able to set the maximum slippage for a pool. To do so, they must call the `setMaxSlippage` function on the Controller contract on mainnet, providing the pool address and the maximum slippage value. Calling this function will carry out the following actions:
 
@@ -2529,9 +2536,11 @@ Only an operator with the admin role is able to set the maximum slippage for a p
 - The contract will set the maximum slippage for the specified pool.
 - The contract will emit a `MaxSlippageSet` event to the blockchain logs.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function setMaxSlippage(address pool, uint256 maxSlippage) external`
+```solidity
+function setMaxSlippage(address pool, uint256 maxSlippage) external
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2 - Relayer Functions [Core]  <!-- UUID: 0a7927fb-3301-423a-9b8f-6eff2c995dd0 -->
 
@@ -2545,7 +2554,7 @@ The documents herein define the operations that are performed to maintain the de
 
 The documents herein define the steps for a relayer to mint USDS from the Sky Allocation Vault to the Keel ALM Proxy.
 
-###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.1.1.1 - Call mintUSDS Function [Core]  <!-- UUID: 768ca90b-8432-456c-8f75-2469514d6969 -->
+###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.1.1.1 - mintUSDS Function [Core]  <!-- UUID: 768ca90b-8432-456c-8f75-2469514d6969 -->
 
 Only an operator with the relayer role is able to mint USDS. To do so, they must call the mintUSDS function on the Controller contract on mainnet with the amount of USDS that is required for minting. Calling this function will carry out the following actions:
 
@@ -2555,15 +2564,17 @@ Only an operator with the relayer role is able to mint USDS. To do so, they must
 - The contract will mint the required USDS into the buffer contract.
 - The contract will transfer the newly minted USDS from the buffer to the Proxy.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function mintUSDS(uint256 usdsAmount) external`
+```solidity
+function mintUSDS(uint256 usdsAmount) external
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.1.2 - Burn USDS [Core]  <!-- UUID: 9c9536a8-bb2d-4d37-98cf-4c25a5699026 -->
 
 The documents herein define the steps for a relayer to return and then burn Keel’s USDS debt in the Sky Allocation Vault.
 
-###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.1.2.1 - Call burnUSDS Function [Core]  <!-- UUID: 59b093a0-9025-4c60-ba6f-7a2e78a35ed4 -->
+###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.1.2.1 - burnUSDS Function [Core]  <!-- UUID: 59b093a0-9025-4c60-ba6f-7a2e78a35ed4 -->
 
 Only an operator with the relayer role is able to repay vault debt and burn USDS. To do so, they must call the burnUSDS function of the Controller contract on mainnet with the amount of USDS that they wish to burn. Calling this function will carry out the following actions:
 
@@ -2572,9 +2583,11 @@ Only an operator with the relayer role is able to repay vault debt and burn USDS
 - The contract will transfer USDS from the proxy to the buffer.
 - The contract will burn the USDS from the buffer and `wipe` an equivalent amount from the vault's debt.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function burnUSDS(uint256 usdsAmount) external`
+```solidity
+function burnUSDS(uint256 usdsAmount) external
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.2 - ERC-20 Functions [Core]  <!-- UUID: 7f8d8294-d5d6-437e-aae1-a1ee36c11e7e -->
 
@@ -2584,7 +2597,7 @@ The documents herein define the operations that are performed to transfer ERC-20
 
 The documents herein define the steps for a relayer to transfer ERC-20 tokens to a destination address.
 
-###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.2.1.1 - Call transferAsset Function [Core]  <!-- UUID: fa55c1fb-83b5-4f73-a7a4-116d2c7814dd -->
+###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.2.1.1 - transferAsset Function [Core]  <!-- UUID: fa55c1fb-83b5-4f73-a7a4-116d2c7814dd -->
 
 Only an operator with the relayer role is able to transfer ERC-20 assets. To do so, they must call the `transferAsset` function on the Controller contract on mainnet, providing the ERC20 asset address, the destination address, and the amount to transfer. Calling this function will carry out the following actions:
 
@@ -2592,9 +2605,11 @@ Only an operator with the relayer role is able to transfer ERC-20 assets. To do 
 - The contract will ensure the `RateLimits` allow for transferring the specified amount of the asset to the destination. If the transfer amount does not fall within the available Rate Limit, the transaction will revert.
 - The contract will execute the ERC-20 `transfer` function, sending the specified amount of the asset to the destination address.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function transferAsset(address asset, address destination, uint256 amount) external`
+```solidity
+function transferAsset(address asset, address destination, uint256 amount) external
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.3 - ERC-4626 Functions [Core]  <!-- UUID: 3de32801-e895-4a21-84da-aa5818d16349 -->
 
@@ -2604,7 +2619,7 @@ The documents herein define the general Keel Liquidity Layer operational procedu
 
 The documents herein define the steps for a relayer to deposit assets from the ALM Proxy to an ERC-4626 vault to receive yield-bearing shares.
 
-###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.3.1.1 - Call depositERC4626 Function [Core]  <!-- UUID: 4e2c13af-7f66-4b87-9662-693e94212c28 -->
+###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.3.1.1 - depositERC4626 Function [Core]  <!-- UUID: 4e2c13af-7f66-4b87-9662-693e94212c28 -->
 
 Only an operator with the relayer role can deposit assets into an ERC-4626 vault. To do so, they must call the `depositERC4626` function on the Controller contract on mainnet, providing the vault token address and the amount of the underlying asset to deposit. The operation will only succeed if the ALM Proxy holds at least the amount of the underlying asset specified for deposit; otherwise, the transaction will revert. The rate limit configuration serves as whitelisting for vaults. Calling this function will carry out the following actions:
 
@@ -2613,15 +2628,17 @@ Only an operator with the relayer role can deposit assets into an ERC-4626 vault
 - The contract will approve the vault to spend the underlying asset from the ALM Proxy. The approval and deposit are both performed from the ALM Proxy address.
 - The contract will deposit the specified amount into the vault, and the ALM Proxy will receive the corresponding number of vault shares.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function depositERC4626(address token, uint256 amount) external returns (uint256 shares)`
+```solidity
+function depositERC4626(address token, uint256 amount) external returns (uint256 shares)
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.3.2 - Withdraw From ERC-4626 Vault [Core]  <!-- UUID: ad2c7a22-96aa-428d-a373-b92fec3b529f -->
 
 The documents herein define the steps for a relayer to withdraw a specified amount of the underlying asset from an ERC-4626 vault to the ALM Proxy.
 
-###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.3.2.1 - Call withdrawERC4626 Function [Core]  <!-- UUID: 37c09b7c-6aa0-4c3c-861e-984de4e3ba4d -->
+###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.3.2.1 - withdrawERC4626 Function [Core]  <!-- UUID: 37c09b7c-6aa0-4c3c-861e-984de4e3ba4d -->
 
 Only an operator with the relayer role can withdraw assets from an ERC-4626 vault. To do so, call the `withdrawERC4626` function on the Controller contract on mainnet, providing the vault token address and the amount of the underlying asset to withdraw. The operation will only succeed if the ALM Proxy holds at least the amount of the underlying asset specified for withdrawal; otherwise, the transaction will revert. When this function is called:
 
@@ -2630,15 +2647,17 @@ Only an operator with the relayer role can withdraw assets from an ERC-4626 vaul
 - The contract will withdraw the specified amount from the vault, burning the necessary number of vault shares held by the ALM Proxy as part of the withdrawal process.
 - The withdrawn assets will be sent to the ALM Proxy.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function withdrawERC4626(address token, uint256 amount) external returns (uint256 shares)`
+```solidity
+function withdrawERC4626(address token, uint256 amount) external returns (uint256 shares)
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.3.3 - Redeem ERC-4626 Shares [Core]  <!-- UUID: eec2b12a-6578-483a-824e-1442f3b0410c -->
 
 The documents herein define the steps for a relayer to redeem vault shares for the underlying asset from an ERC-4626 vault, with the assets sent to the ALM Proxy.
 
-###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.3.3.1 - Call redeemERC4626 Function [Core]  <!-- UUID: a6474ee7-317b-430b-abd7-bf81a50ca898 -->
+###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.3.3.1 - redeemERC4626 Function [Core]  <!-- UUID: a6474ee7-317b-430b-abd7-bf81a50ca898 -->
 
 Only an operator with the relayer role can redeem vault shares for the underlying asset. To do so, they must call the `redeemERC4626` function on the Controller contract on mainnet, providing the number of shares to redeem. The address is the ALM Proxy acting as both the owner of the shares being redeemed and the receiver of the resulting assets. The operation will only succeed if the ALM Proxy holds at least the number of shares specified for redemption; otherwise, the transaction will revert. When this function is called:
 
@@ -2646,9 +2665,11 @@ Only an operator with the relayer role can redeem vault shares for the underlyin
 - The contract will redeem the specified number of shares from the vault, sending the resulting assets to the ALM Proxy.
 - After redemption, the contract will update the withdrawal rate limit based on the amount of assets received.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function redeemERC4626(address token, uint256 shares) external returns (uint256 assets)`
+```solidity
+function redeemERC4626(address token, uint256 shares) external returns (uint256 assets)
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.4 - ERC-7540 Functions [Core]  <!-- UUID: ff9638aa-a4d5-4a5e-a2bb-9b924b9987f9 -->
 
@@ -2658,7 +2679,7 @@ The documents herein define the general Keel Liquidity Layer operational procedu
 
 The documents herein define the steps for a relayer to request and claim deposit of assets from the ALM Proxy to an ERC-7540 vault.
 
-###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.4.1.1 - Call requestDepositERC7540 Function [Core]  <!-- UUID: e86cf2c1-31f6-4f83-8120-89b52611adae -->
+###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.4.1.1 - requestDepositERC7540 Function [Core]  <!-- UUID: e86cf2c1-31f6-4f83-8120-89b52611adae -->
 
 Only an operator with the relayer role can request a deposit into an ERC-7540 vault. To do so, they must call the `requestDepositERC7540` function on the Controller contract on mainnet, providing the vault token address and the amount of the underlying asset to deposit. The operation will only succeed if the ALM Proxy holds at least the amount of the underlying asset specified for deposit; otherwise, the transaction will revert. The Rate Limit configuration serves as whitelisting for vaults. Calling this function will carry out the following actions:
 
@@ -2667,11 +2688,13 @@ Only an operator with the relayer role can request a deposit into an ERC-7540 va
 - The contract will approve the vault to spend the underlying asset from the ALM Proxy. The approval and deposit request are both performed from the ALM Proxy address.
 - The contract will submit a deposit request to the vault. Shares will not be received immediately; they must be claimed in a separate step after the vault processes the deposit.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function requestDepositERC7540(address token, uint256 amount) external`
+```solidity
+function requestDepositERC7540(address token, uint256 amount) external
+```
 
-###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.4.1.2 - Call claimDepositERC7540 Function [Core]  <!-- UUID: cb81a01a-74b8-4e35-a83d-0848dd1f9f14 -->
+###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.4.1.2 - claimDepositERC7540 Function [Core]  <!-- UUID: cb81a01a-74b8-4e35-a83d-0848dd1f9f14 -->
 
 Only an operator with the relayer role can claim shares from an ERC-7540 vault after a deposit request. To do so, they must call the `claimDepositERC7540` function on the Controller contract on mainnet, providing the vault token address. Calling this function will carry out the following actions:
 
@@ -2679,15 +2702,17 @@ Only an operator with the relayer role can claim shares from an ERC-7540 vault a
 - The contract will determine the maximum number of shares that can be claimed by the ALM Proxy.
 - The contract will claim the shares from the vault, and the ALM Proxy will receive the corresponding number of vault shares.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function claimDepositERC7540(address token) external`
+```solidity
+function claimDepositERC7540(address token) external
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.4.2 - Redeem From ERC-7540 Vault [Core]  <!-- UUID: 7077efbf-91fb-402c-831f-8f15e13f0a6a -->
 
 The documents herein define the steps for a relayer to request and redeem vault shares for the underlying asset from an ERC-7540 vault, with the assets sent to the ALM Proxy.
 
-###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.4.2.1 - Call requestRedeemERC7540 Function [Core]  <!-- UUID: 19e6bba4-8d6f-4d1c-95d5-000b2dbf948c -->
+###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.4.2.1 - requestRedeemERC7540 Function [Core]  <!-- UUID: 19e6bba4-8d6f-4d1c-95d5-000b2dbf948c -->
 
 Only an operator with the relayer role can request the redemption of shares from an ERC-7540 vault. To do so, they must call the `requestRedeemERC7540` function on the Controller contract on mainnet, providing the vault token address and the number of shares to redeem. The rate limit configuration serves as whitelisting for vaults. Calling this function will carry out the following actions:
 
@@ -2695,11 +2720,13 @@ Only an operator with the relayer role can request the redemption of shares from
 - The contract will ensure the redemption amount is within the allowed rate limit for the specified vault.
 - The contract will submit a redemption request to the vault. Assets will not be received immediately; they must be claimed in a separate step after the vault processes the redemption.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function requestRedeemERC7540(address token, uint256 amount) external`
+```solidity
+function requestRedeemERC7540(address token, uint256 shares) external
+```
 
-###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.4.2.2 - Call claimRedeemERC7540 Function [Core]  <!-- UUID: 9b43cc7e-dfb9-4868-b9a6-8848c837691b -->
+###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.4.2.2 - claimRedeemERC7540 Function [Core]  <!-- UUID: 9b43cc7e-dfb9-4868-b9a6-8848c837691b -->
 
 Only an operator with the relayer role can claim assets from an ERC-7540 vault after a redemption request. To do so, they must call the `claimRedeemERC7540` function on the Controller contract on mainnet, providing the vault token address. Calling this function will carry out the following actions:
 
@@ -2707,9 +2734,11 @@ Only an operator with the relayer role can claim assets from an ERC-7540 vault a
 - The contract will determine the maximum amount of assets that can be claimed by the ALM Proxy.
 - The contract will claim the assets from the vault, and the ALM Proxy will receive the corresponding amount of underlying assets.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function claimRedeemERC7540(address token) external`
+```solidity
+function claimRedeemERC7540(address token) external
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.5 - PSM Functions [Core]  <!-- UUID: 19d426c4-9846-4ea8-91f7-5b6d71055491 -->
 
@@ -2719,7 +2748,7 @@ The documents herein define the swap operations performed by the Keel Liquidity 
 
 The documents herein define a series of operations for an operator to `swap` USDS to USDC through the PSM.
 
-###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.5.1.1 - Call swapUSDSToUSDC Function [Core]  <!-- UUID: df09edaf-7a92-4d8e-ae86-a9666a0bf082 -->
+###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.5.1.1 - swapUSDSToUSDC Function [Core]  <!-- UUID: df09edaf-7a92-4d8e-ae86-a9666a0bf082 -->
 
 Only an operator with the relayer role can swap USDS to USDC via the PSM. To do so, they must call the swapUSDSToUSDC function on the Controller contract on mainnet, providing the usdcAmount (denominated in 1e6 precision to match PSM USDC handling). The operation will only succeed if the ALM Proxy holds at least the equivalent amount of USDS for the swap; otherwise, the transaction will revert. The rate limit configuration serves as whitelisting for swaps. Calling this function will carry out the following actions:
 
@@ -2731,15 +2760,17 @@ Only an operator with the relayer role can swap USDS to USDC via the PSM. To do 
 - The contract will approve the PSM to spend the DAI.
 - The contract will swap DAI to USDC at a 1:1 ratio with no fee via psm.buyGemNoFee, sending USDC to the proxy.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function swapUSDSToUSDC(uint256 usdcAmount) external`
+```solidity
+function swapUSDSToUSDC(uint256 usdcAmount) external
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.5.2 - Swap USDC To USDS [Core]  <!-- UUID: da2164e3-03bc-447c-89c5-119d01feddaa -->
 
 The documents herein define a series of operations for an operator to `swap` USDC to USDS through the PSM.
 
-###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.5.2.1 - Call swapUSDCToUSDS Function [Core]  <!-- UUID: 1b18072b-c409-4d2f-a333-1e5c3ae8ab90 -->
+###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.5.2.1 - swapUSDCToUSDS Function [Core]  <!-- UUID: 1b18072b-c409-4d2f-a333-1e5c3ae8ab90 -->
 
 Only an operator with the relayer role can swap USDC to USDS via the PSM. To do so, they must call the `swapUSDCToUSDS` function on the Controller contract on mainnet, providing the usdcAmount (denominated in 1e6 precision to match PSM USDC handling). The operation will only succeed if the ALM Proxy holds at least the amount of USDC specified for the swap; otherwise, the transaction will revert. The rate limit configuration serves as whitelisting for swaps. Calling this function will carry out the following actions:
 
@@ -2753,15 +2784,17 @@ Only an operator with the relayer role can swap USDC to USDS via the PSM. To do 
 - The contract will approve the daiUsds contract to spend the DAI amount from the ALM Proxy.
 - The contract will swap DAI to USDS at a 1:1 ratio via daiUsds, sending USDS to the proxy.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function swapUSDCToUSDS(uint256 usdcAmount) external`
+```solidity
+function swapUSDCToUSDS(uint256 usdcAmount) external
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.5.3 - Transfer Token Via LayerZero [Core]  <!-- UUID: 030c5483-6126-40f7-b7ff-a99186ab105d -->
 
 The documents herein define the steps for a relayer to transfer a token via LayerZero to a destination endpoint, with the assets sent according to the configured recipient.
 
-###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.5.3.1 - Call transferTokenLayerZero Function [Core]  <!-- UUID: f88e14a0-fa64-44cc-a52c-cb35b7704ee8 -->
+###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.5.3.1 - transferTokenLayerZero Function [Core]  <!-- UUID: f88e14a0-fa64-44cc-a52c-cb35b7704ee8 -->
 
 Only an operator with the relayer role can transfer tokens via LayerZero. To do so, they must call the `transferTokenLayerZero` function on the Controller contract on mainnet, providing the oftAddress, amount, and destinationEndpointId (payable for native fees). The operation will only succeed if the ALM Proxy holds sufficient tokens and fees; otherwise, the transaction will revert. Calling this function will carry out the following actions:
 
@@ -2772,9 +2805,11 @@ Only an operator with the relayer role can transfer tokens via LayerZero. To do 
 - The contract will quote the OFT receipt to set the minimum amount received.
 - The contract will quote the messaging fee and execute the send via proxy.doCallWithValue, passing the fee value.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function transferTokenLayerZero(address oftAddress, uint256 amount, uint32  destinationEndpointId) external payable`
+```solidity
+function transferTokenLayerZero(address oftAddress, uint256 amount, uint32 destinationEndpointId) external payable
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.6 - Bridging Functions [Core]  <!-- UUID: 66d40b48-7f80-46a2-8ee0-503580a42d4c -->
 
@@ -2784,7 +2819,7 @@ The documents herein define the operations performed by an operator to bridge li
 
 The documents herein define the process to bridge USDC using the Circle Cross-Chain Transfer Protocol.
 
-###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.6.1.1 - Call transferUSDCToCCTP Function [Core]  <!-- UUID: 46a74cd0-5e4e-4ea6-8fe6-ab38a8930f32 -->
+###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.6.1.1 - transferUSDCToCCTP Function [Core]  <!-- UUID: 46a74cd0-5e4e-4ea6-8fe6-ab38a8930f32 -->
 
 Only an operator with the relayer role can initiate a USDC transfer to a specified destination domain using CCTP, handling rate limits, approvals, and splitting large amounts if needed. It requires parameters like proxy, Rate Limits, cctp, usdc, rate limit IDs, mintRecipient, destinationDomain, and usdcAmount. To do so, they must call the `transferUSDCToCCTP` function on the Controller contract on mainnet. Calling this function will carry out the following actions:
 
@@ -2797,9 +2832,11 @@ Only an operator with the relayer role can initiate a USDC transfer to a specifi
 - If the usdcAmount exceeds the burn limit, the contract will initiate a CCTP transfer for the burn limit amount and subtract it from the remaining usdcAmount.
 - If any usdcAmount remains after the loop, the contract will initiate a final CCTP transfer for that amount.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function transferUSDCToCCTP(uint256 usdcAmount, uint32 destinationDomain) external`
+```solidity
+function transferUSDCToCCTP(uint256 usdcAmount, uint32 destinationDomain) external
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.6.2 - Bridge USDS / sUSDS Using SkyBridge (LayerZero OFT) Token Bridge [Core]  <!-- UUID: d239ba22-9a09-49f1-9fdc-a1d306ffe697 -->
 
@@ -2815,9 +2852,11 @@ Anyone can query the full rate limit data for a specific key. Calling this funct
 
 - The contract will return the stored RateLimitData struct from the _data mapping for the key.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function getRateLimitData(bytes32 key) external override view returns (RateLimitData memory)`
+```solidity
+function getRateLimitData(bytes32 key) external override view returns (RateLimitData memory)
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.3.2 - Set Rate Limit Data [Core]  <!-- UUID: 132f4de3-5b4c-462b-8f03-4cc15706baaf -->
 
@@ -2828,11 +2867,15 @@ Only an operator with the admin role is able to set or update rate limit data fo
 - The contract will store the provided data in the _data mapping as a RateLimitData struct.
 - The contract will emit a RateLimitDataSet event with the key and provided values.
 
-The function calls are as follows:
+The function signatures are as follows:
 
-`function setRateLimitData(bytes32 key, uint256 maxAmount, uint256 slope, uint256 lastAmount, uint256 lastUpdated) public override onlyRole(DEFAULT_ADMIN_ROLE)
+```solidity
+function setRateLimitData(bytes32 key, uint256 maxAmount, uint256 slope, uint256 lastAmount, uint256 lastUpdated) public override onlyRole(DEFAULT_ADMIN_ROLE)
+```
 
-function setRateLimitData(bytes32 key, uint256 maxAmount, uint256 slope) external override`
+```solidity
+function setRateLimitData(bytes32 key, uint256 maxAmount, uint256 slope) external override
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.3.3 - Set Unlimited Rate Limit Data [Core]  <!-- UUID: 0a5ccc61-eaf4-4b49-80d7-770e29178c1a -->
 
@@ -2840,9 +2883,11 @@ Only an operator with the admin role is able to set unlimited rate limit data fo
 
 - The contract will call setRateLimitData internally with type(uint256).max for maxAmount and lastAmount, 0 for slope, and the current block timestamp for lastUpdated.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function setUnlimitedRateLimitData(bytes32 key) external override`
+```solidity
+function setUnlimitedRateLimitData(bytes32 key) external override
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.3.4 - Get Current Rate Limit [Core]  <!-- UUID: 99f4fe4c-04af-4efe-b099-f5d92122de78 -->
 
@@ -2852,9 +2897,11 @@ Anyone can query the current rate limit value for a specific key, accounting for
 - If maxAmount is type(uint256).max (unlimited case), the contract will return type(uint256).max.
 - Otherwise, the contract will calculate and return the minimum of (slope * time elapsed since lastUpdated + lastAmount) and maxAmount.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function getCurrentRateLimit(bytes32 key) public override view returns (uint256)`
+```solidity
+function getCurrentRateLimit(bytes32 key) public override view returns (uint256)
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.3.5 - Trigger Rate Limit Decrease [Core]  <!-- UUID: a710528f-e695-4262-bab1-e5ee57241315 -->
 
@@ -2869,9 +2916,11 @@ Only an operator with the controller role can trigger a decrease in the rate lim
 - The contract will emit a RateLimitDecreaseTriggered event with the key, amountToDecrease, currentRateLimit, and newLimit.
 - The contract will return the newLimit.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function triggerRateLimitDecrease(bytes32 key, uint256 amountToDecrease) external override onlyRole(CONTROLLER) returns (uint256 newLimit)`
+```solidity
+function triggerRateLimitDecrease(bytes32 key, uint256 amountToDecrease) external override onlyRole(CONTROLLER) returns (uint256 newLimit)
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.1.4 - Instance Lifecycle Management [Core]  <!-- UUID: 724970e4-e5e7-41ff-9448-d984c2c9a9e3 -->
 
@@ -2897,9 +2946,11 @@ In the event of a compromised Relayer, the `FREEZER_ROLE` can call the function 
 - The contract will revoke the relayer role from the specified address.
 - The contract will emit a `RelayerRemoved(relayer)` event.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function removeRelayer(address relayer) external`
+```solidity
+function removeRelayer(address relayer) external
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.1.3.2 - Redeem All Ethereum Mainnet Positions [Core]  <!-- UUID: 23a36776-11e0-4c65-a25d-500a44e14eb4 -->
 
@@ -2911,7 +2962,9 @@ In order to withdraw all ERC-4626 balances, the operator must call the `redeemER
 
 The function call is as follows:
 
-`function redeemERC4626(address(token), token.balanceOf(address(proxy)))`
+```solidity
+redeemERC4626(address(token), token.balanceOf(address(proxy)))
+```
 
 For more detailed instructions on the code to execute this, see [A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.3 - ERC-4626 Functions](3de32801-e895-4a21-84da-aa5818d16349).
 
@@ -2921,7 +2974,9 @@ This document defines the action that should be performed by an operator if ther
 
 The function call is as follows:
 
-`function swapUSDCToUSDS(usdc.balanceOf(address(proxy))`
+```solidity
+swapUSDCToUSDS(usdc.balanceOf(address(proxy)))
+```
 
 For more detailed instructions on the code to execute this see [A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.5.2 - Swap USDC To USDS](da2164e3-03bc-447c-89c5-119d01feddaa).
 
@@ -2931,7 +2986,9 @@ This document defines the action that should be performed if there is a need to 
 
 The function call is as follows:
 
-`function burnUSDS(usds.balanceOf(address(proxy))`
+```solidity
+burnUSDS(usds.balanceOf(address(proxy)))
+```
 
 More detailed instructions on the code to execute this, see [A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.1.2 - Burn USDS](9c9536a8-bb2d-4d37-98cf-4c25a5699026).
 
@@ -2951,8 +3008,11 @@ The documents herein define roles (Admin, Relayer, ALM Controller and Freezer) a
 
 The admin role is configured with the following permissions: `can_freeze_controller`, `can_unfreeze_controller`, `can_manage_permissions`, `can_suspend_permissions`, `can_manage_reserves_and_integrations`, `can_invoke_external_transfer`. This role can grant and revoke any role, including itself and all other roles defined in the contract. The admin role is also used for general admin functions in all contracts. This role is fully controlled by Sky Governance via the Keel Proxy.
 
-`constructor(address admin) {
-_grantRole(DEFAULT_ADMIN_ROLE, admin);`
+```solidity
+constructor(address admin_) {
+    _grantRole(DEFAULT_ADMIN_ROLE, admin_);
+}
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.2.1.1.2 - Relayer Role [Core]  <!-- UUID: 2b42015c-c76a-4364-b8b5-c9a2b9f6f484 -->
 
@@ -3030,38 +3090,44 @@ The documents herein define the protocol for querying, setting, and adjusting Ra
 
 The properties associated with a Reserve level rate limit can be read from the `Reserve` account corresponding to a particular token, as follows:
 
-`pub struct Reserve {
-// ...
-pub rate_limit_slope: u64,
-pub rate_limit_max_outflow: u64,
-pub rate_limit_outflow_amount_available: u64,
-pub rate_limit_remainder: u64
-// ...
-}`
+```rust
+pub struct Reserve {
+    // ...
+    pub rate_limit_slope: u64,
+    pub rate_limit_max_outflow: u64,
+    pub rate_limit_outflow_amount_available: u64,
+    pub rate_limit_remainder: u64
+    // ...
+}
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.2.1.3.1.2 - Set Rate Limit Data [Core]  <!-- UUID: aa43f1e6-6ee6-4596-a288-f79685cd8144 -->
 
 Only an operator with the [A.6.1.1.3.2.6.1.2.2.2.1.1.1 - Default Admin Role](0270b595-8957-4fb2-a9cd-2bc197dc3367) is able to set or update rate limit data for a specific `Reserve`, including `rate_limit_slope` and `rate_limit_max_outflow`.
 
-`manage_reserves(
-ManageReserveArgs {
-status: None,
-rate_limit_slope: Some(rate_limit_slope),
-rate_limit_max_outflow: Some(rate_limit_max_outflow),
-}
-)`
+```rust
+manage_reserves(
+    ManageReserveArgs {
+        status: None,
+        rate_limit_slope: Some(rate_limit_slope),
+        rate_limit_max_outflow: Some(rate_limit_max_outflow),
+    }
+)
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.2.1.3.1.3 - Set Unlimited Rate Limit Data [Core]  <!-- UUID: 76946aaf-70dc-43cf-a6e0-ce947f19b93b -->
 
 Only an operator with the [A.6.1.1.3.2.6.1.2.2.2.1.1.1 - Default Admin Role](0270b595-8957-4fb2-a9cd-2bc197dc3367) is able to set unlimited rate limit data for a specific key by configuring it with maximum values.
 
-`manage_reserves(
-ManageReserveArgs {
-status: None,
-rate_limit_slope: Some(0),
-rate_limit_max_outflow: Some(u64::MAX),
-}
-)`
+```rust
+manage_reserves(
+    ManageReserveArgs {
+        status: None,
+        rate_limit_slope: Some(0),
+        rate_limit_max_outflow: Some(u64::MAX),
+    }
+)
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.2.1.3.2 - Integration Level Rate Limits [Core]  <!-- UUID: 3bf06ac1-44d2-4901-92fb-7af3cebef5a0 -->
 
@@ -3071,40 +3137,46 @@ rate_limit_max_outflow: Some(u64::MAX),
 
 The properties associated with a Reserve level rate limit can be read from the `Integration` account corresponding to a particular token, as follows:
 
-`pub struct Integration {
-// ...
-pub rate_limit_slope: u64,
-pub rate_limit_max_outflow: u64,
-pub rate_limit_outflow_amount_available: u64,
-pub rate_limit_remainder: u64
-// ...
-}`
+```rust
+pub struct Integration {
+    // ...
+    pub rate_limit_slope: u64,
+    pub rate_limit_max_outflow: u64,
+    pub rate_limit_outflow_amount_available: u64,
+    pub rate_limit_remainder: u64
+    // ...
+}
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.2.1.3.2.2 - Set Rate Limit Data [Core]  <!-- UUID: 62654961-cf70-4455-a7df-c81861944395 -->
 
 Only an operator with the [A.6.1.1.3.2.6.1.2.2.2.1.1.1 - Default Admin Role](0270b595-8957-4fb2-a9cd-2bc197dc3367) is able to set or update rate limit data for a specific `Integration`, including `rate_limit_slope` and `rate_limit_max_outflow`.
 
-`manage_integration(
-ManageIntegrationArgs {
-status: None,
-description: None,
-rate_limit_slope: Some(rate_limit_slope),
-rate_limit_max_outflow: Some(rate_limit_max_outflow),
-}
-)`
+```rust
+manage_integration(
+    ManageIntegrationArgs {
+        status: None,
+        description: None,
+        rate_limit_slope: Some(rate_limit_slope),
+        rate_limit_max_outflow: Some(rate_limit_max_outflow),
+    }
+)
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.2.1.3.2.3 - Set Unlimited Rate Limit Data [Core]  <!-- UUID: bd904ac0-32d2-4592-92cd-3eb01a3ce7de -->
 
 Only an operator with the [A.6.1.1.3.2.6.1.2.2.2.1.1.1 - Default Admin Role](0270b595-8957-4fb2-a9cd-2bc197dc3367) is able to set unlimited rate limit data for a specific key by configuring it with maximum values.
 
-`manage_integration(
-ManageIntegrationArgs {
-status: None,
-description: None,
-rate_limit_slope: Some(0),
-rate_limit_max_outflow: Some(u64::MAX),
-}
-)`
+```rust
+manage_integration(
+    ManageIntegrationArgs {
+        status: None,
+        description: None,
+        rate_limit_slope: Some(0),
+        rate_limit_max_outflow: Some(u64::MAX),
+    }
+)
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.2.1.4 - Instance Lifecycle Management [Core]  <!-- UUID: 5fcff9f8-7f6d-427d-a12d-02df83b4db6e -->
 
@@ -3126,20 +3198,22 @@ The documents herein define all the possible actions that can be taken in case o
 
 In the event of a compromised Relayer, the [A.6.1.1.3.2.6.1.2.2.2.1.1.3 - Freezer Role](6f7becc7-2e70-44e5-8662-25ba7dd1a5f8) and [A.6.1.1.3.2.6.1.2.2.2.1.1.1 - Default Admin Role](0270b595-8957-4fb2-a9cd-2bc197dc3367) can call the instruction to suspend the compromised Relayer from the Controller program, thereby preventing it from doing any further harm to the system. The backstop Relayer can then take over. This function should only be used if the keys to the Relayer multisig have been leaked or compromised, and the Relayer is now in the hands of an external bad actor.
 
-`manage_permission(
-ManagePermissionArgs {
-status: PermissionStatus::Suspended,
-can_manage_permissions: false,
-can_invoke_external_transfer: false,
-can_execute_swap: false,
-can_reallocate: false,
-can_freeze_controller: false,
-can_unfreeze_controller: false,
-can_manage_reserves_and_integrations: false,
-can_suspend_permissions: false,
-can_liquidate: false,
-}
-)`
+```rust
+manage_permission(
+    ManagePermissionArgs {
+        status: PermissionStatus::Suspended,
+        can_manage_permissions: false,
+        can_invoke_external_transfer: false,
+        can_execute_swap: false,
+        can_reallocate: false,
+        can_freeze_controller: false,
+        can_unfreeze_controller: false,
+        can_manage_reserves_and_integrations: false,
+        can_suspend_permissions: false,
+        can_liquidate: false,
+    }
+)
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.2.3.2 - Freeze the Controller [Core]  <!-- UUID: de48d076-bad2-4edd-a740-0e5ee9173d0d -->
 
@@ -3149,21 +3223,25 @@ In the event of a more severe threat to the Controller, the [A.6.1.1.3.2.6.1.2.2
 
 This action leads to a complete freeze and prevents any actions on the Controller until the [A.6.1.1.3.2.6.1.2.2.2.1.1.1 - Default Admin Role](0270b595-8957-4fb2-a9cd-2bc197dc3367) subsequently lifts this status. Integrations, Reserves nor Permissions cannot be managed during this period, and funds cannot be moved.
 
-`manage_controller(
-ManageControllerArgs {
-status: ControllerStatus::PushPullFrozen,
-}
-)`
+```rust
+manage_controller(
+    ManageControllerArgs {
+        status: ControllerStatus::PushPullFrozen,
+    }
+)
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.2.3.2.2 - Reallocation Freeze [Core]  <!-- UUID: 2ed41eef-989b-4253-8de7-5e368da0242a -->
 
 A complete freeze prevents any movement of funds within the Controller until the [A.6.1.1.3.2.6.1.2.2.2.1.1.1 - Default Admin Role](0270b595-8957-4fb2-a9cd-2bc197dc3367) subsequently lifts this status. Integrations, Reserves and Permissions cannot be configured during this period.
 
-`manage_controller(
-ManageControllerArgs {
-status: ControllerStatus::Frozen,
-}
-)`
+```rust
+manage_controller(
+    ManageControllerArgs {
+        status: ControllerStatus::Frozen,
+    }
+)
+```
 
 ###### A.6.1.1.3.2.6.1.2.2.2.3.3 - Redeem All Positions [Core]  <!-- UUID: 4f4a2911-a604-4203-8103-e9a05fe4cb80 -->
 
@@ -3181,7 +3259,9 @@ This will be specified in a future iteration of the Keel Artifact.
 
 This document defines the action that should be performed by an operator if there is a need to centralize all recovered liquidity in USDS.
 
-`mainnetController.swapUSDCToUSDS(usdc.balanceOf(address(proxy))`
+```solidity
+mainnetController.swapUSDCToUSDS(usdc.balanceOf(address(proxy)))
+```
 
 For more detailed instructions on the code to execute this see [A.6.1.1.3.2.6.1.2.2.1.1.2.1.2.5.2 - Swap USDC To USDS](da2164e3-03bc-447c-89c5-119d01feddaa).
 

--- a/content/A.6.1.1.4 - Skybase.md
+++ b/content/A.6.1.1.4 - Skybase.md
@@ -1000,6 +1000,14 @@ This Instance’s associated Instance Configuration Document is located at [A.6.
 
 This Instance’s associated Instance Configuration Document is located at [A.6.1.1.4.2.5.1.2.8 - Lazy Summer Protocol Instance Configuration Document](74db9986-5277-4c5f-8e27-f6a312ed591f).
 
+###### A.6.1.1.4.2.5.1.1.2.9 - 1inch Instance Configuration Document Location [Core]  <!-- UUID: 3e912483-4917-49ec-94d7-3580fcf19a5a -->
+
+This Instance’s associated Instance Configuration Document is located at [A.6.1.1.4.2.5.1.2.9 - 1inch Instance Configuration Document](f7822e03-78d1-4f8f-82d1-843642ad2bc7).
+
+###### A.6.1.1.4.2.5.1.1.2.10 - Kyber Instance Configuration Document Location [Core]  <!-- UUID: 221cb53c-d13f-4271-bc1f-5db385c163ec -->
+
+This Instance’s associated Instance Configuration Document is located at [A.6.1.1.4.2.5.1.2.10 - Kyber Instance Configuration Document](0a105e94-04ac-4c44-8d84-f8c89cc0935b).
+
 ###### A.6.1.1.4.2.5.1.1.3 - Completed Instances Directory [Core]  <!-- UUID: 3c43db85-3995-4c95-a85c-e72786a28501 -->
 
 This document contains a Directory of all Instances of the Distribution Reward Primitive with Instance status of `Completed`.
@@ -1786,6 +1794,200 @@ The payment details consist of a table where each entry represents a single paym
 - Transaction Date
 
 ###### A.6.1.1.4.2.5.1.2.8.3.5.0.6.2 - Third Party Partner Payment Addresses [Active Data]  <!-- UUID: 08771b54-8577-44ee-9edb-1915c0f6f050 -->
+
+The payment address of this Third Party Partner will be defined in a future iteration of the Skybase Artifact.
+
+###### A.6.1.1.4.2.5.1.2.9 - 1inch Instance Configuration Document [Core]  <!-- UUID: f7822e03-78d1-4f8f-82d1-843642ad2bc7 -->
+
+The documents herein contain the Instance Configuration Document for the 1inch Distribution Reward Primitive Instance.
+
+###### A.6.1.1.4.2.5.1.2.9.1 - Parameters [Core]  <!-- UUID: cf4e40ea-595b-4c1d-88b7-c20553e01999 -->
+
+The documents herein define the parameters of the 1inch Instance of the Distribution Reward Primitive.
+
+###### A.6.1.1.4.2.5.1.2.9.1.1 - Reward Code [Core]  <!-- UUID: 789eeb5c-9f86-40b9-a807-12835a56d0d8 -->
+
+`1020`.
+
+###### A.6.1.1.4.2.5.1.2.9.1.2 - Tracking Methodology [Core]  <!-- UUID: 027c5736-97f7-4a80-93b9-f54b0fb3e97c -->
+
+This Instance uses the Tracking Methodology specified in [A.2.2.9.1.2.1.1.2.1 - Ethereum Mainnet General Tracking Methodology](87fd6861-ba8a-4bde-945e-ee9ad37ae3e2).
+
+###### A.6.1.1.4.2.5.1.2.9.1.3 - Custom Instance Parameters [Core]  <!-- UUID: 1af86e65-ee7e-48e0-9207-0ae78a65e9a6 -->
+
+The documents herein define the custom parameters of the 1inch Instance of the Distribution Reward Primitive, if any.
+
+###### A.6.1.1.4.2.5.1.2.9.2 - Operational Process Definition [Core]  <!-- UUID: 402f16b8-eae4-4b2e-90eb-08dc7d98b25a -->
+
+The documents herein define the process for the ongoing management of the 1inch Instance of the Distribution Reward Primitive.
+
+###### A.6.1.1.4.2.5.1.2.9.2.1 - Routine Protocol [Core]  <!-- UUID: 2a59d420-a468-4072-af1a-4e2ccf2e6191 -->
+
+This document defines the protocol for routine ongoing management of the 1inch Instance. This Instance inherits the base class of operational logic defined in [A.2.2.9.1.2.4.1 - Routine Protocol](c2abdd22-fe0f-489e-b281-450e066db701), subject to the qualifications specified in [A.2.2.9.1.2.1.3.3.1 - Near-Term Process](05fb732b-de55-4886-81a7-7c5d4c13d2d2).
+
+Modifications to the base operational logic automatically propagate to this Instance. In future iterations of the Skybase Artifact, a version of the full process definition customized to Skybase will be included herein.
+
+###### A.6.1.1.4.2.5.1.2.9.2.1.1 - Agent Customizations [Core]  <!-- UUID: 2173c4c6-0e43-41ca-8415-9de02c654a98 -->
+
+The Prime Agent may define Instance-specific customization of the routine protocol to extend the baseline functionality defined in the Sky Core Atlas. This can include custom routines or processes layered on top of the inherited Sky Core logic. Any extensions must remain fully aligned with the requirements specified in the Sky Core Atlas. This document defines those customizations, if any.
+
+[No customization presently.]
+
+###### A.6.1.1.4.2.5.1.2.9.2.2 - Non-Routine Protocol [Core]  <!-- UUID: 358f1183-f368-449a-959f-2fc1aaf91acb -->
+
+The documents herein define the protocol for non-routine ongoing management of the 1inch Instance of this Distribution Reward Primitive.
+
+###### A.6.1.1.4.2.5.1.2.9.2.3 - Emergency Protocol [Core]  <!-- UUID: e866937f-a10a-42a0-949d-28575ada4bf9 -->
+
+The documents herein define the protocol for handling emergency situations in the ongoing management of the 1inch Instance of this Distribution Reward Primitive.
+
+###### A.6.1.1.4.2.5.1.2.9.3 - Data Repository [Core]  <!-- UUID: 21ccfd7f-0a5a-40f1-ab2c-ad57aa2b73d2 -->
+
+The documents herein contain data relevant to the 1inch Instance of the Distribution Reward Primitive.
+
+###### A.6.1.1.4.2.5.1.2.9.3.1 - Initial Planning [Core]  <!-- UUID: 2e3f0833-0f2f-4940-bc1e-e3adf68e41de -->
+
+The materials associated with initial planning of the Invocation of this Instance are contained herein.
+
+###### A.6.1.1.4.2.5.1.2.9.3.2 - Operational GovOps Review [Core]  <!-- UUID: a78d37f7-cb9d-47ba-a956-cbdabe547efb -->
+
+The materials associated with Operational GovOps Review during the Invocation of this Instance are contained herein.
+
+###### A.6.1.1.4.2.5.1.2.9.3.3 - Artifact Edit Proposal [Core]  <!-- UUID: d9d79d33-b9ee-4c8e-a90d-b84f71dd7d54 -->
+
+The materials associated with preparing the Artifact Edit Proposal during the Invocation of this Instance are contained herein.
+
+###### A.6.1.1.4.2.5.1.2.9.3.4 - Distribution Reward Payments [Active Data Controller]  <!-- UUID: c3075307-a661-4128-882f-b07107b54659 -->
+
+The Distribution Reward payments for the 1inch Instance of the Distribution Reward Primitive are defined as Active Data.
+
+The Active Data is updated as follows:
+
+- The Responsible Party is Operational GovOps.
+- The Update Process must follow the protocol for ‘Direct Edit’.
+
+###### A.6.1.1.4.2.5.1.2.9.3.4.0.6.1 - List Of Distribution Reward Payments [Active Data]  <!-- UUID: 4e79d3fa-29fc-41c6-b500-f379b5267416 -->
+
+The Distribution Reward Payments are:
+
+###### A.6.1.1.4.2.5.1.2.9.3.5 - Third Party Partner Payment Addresses And Transaction Records [Active Data Controller]  <!-- UUID: dd244aef-f02b-43f9-af7d-74f26fdfd776 -->
+
+This Document records information pertaining to Skybase's payments to the Third Party Partner associated with this Instance. This information is defined as Active Data.
+
+The Active Data is updated as follows:
+
+- The Responsible Party is Operational GovOps.
+- The Update Process must follow the protocol for ‘Direct Edit’.
+
+###### A.6.1.1.4.2.5.1.2.9.3.5.0.6.1 - Payment Details Per Reward Period [Active Data]  <!-- UUID: c80530b0-c4df-4314-ab87-92055422707e -->
+
+The payment details consist of a table where each entry represents a single payment. Each entry has the following fields:
+
+- Reward Period
+- Payee
+- Payment Address
+- Amount Paid
+- Transaction Hash
+- Transaction Date
+
+###### A.6.1.1.4.2.5.1.2.9.3.5.0.6.2 - Third Party Partner Payment Addresses [Active Data]  <!-- UUID: fbfc957c-adc0-44b1-a16a-ceb0284a2a51 -->
+
+The payment address of this Third Party Partner will be defined in a future iteration of the Skybase Artifact.
+
+###### A.6.1.1.4.2.5.1.2.10 - Kyber Instance Configuration Document [Core]  <!-- UUID: 0a105e94-04ac-4c44-8d84-f8c89cc0935b -->
+
+The documents herein contain the Instance Configuration Document for the Kyber Distribution Reward Primitive Instance.
+
+###### A.6.1.1.4.2.5.1.2.10.1 - Parameters [Core]  <!-- UUID: 99f977b9-533f-4526-99d8-729f005c442f -->
+
+The documents herein define the parameters of the Kyber Instance of the Distribution Reward Primitive.
+
+###### A.6.1.1.4.2.5.1.2.10.1.1 - Reward Code [Core]  <!-- UUID: 3a8294c7-459f-418c-8713-aa306dff1d04 -->
+
+`1021`.
+
+###### A.6.1.1.4.2.5.1.2.10.1.2 - Tracking Methodology [Core]  <!-- UUID: 0eeabad3-410e-4001-b0da-fa73caf4ce6b -->
+
+This Instance uses the Tracking Methodology specified in [A.2.2.9.1.2.1.1.2.1 - Ethereum Mainnet General Tracking Methodology](87fd6861-ba8a-4bde-945e-ee9ad37ae3e2).
+
+###### A.6.1.1.4.2.5.1.2.10.1.3 - Custom Instance Parameters [Core]  <!-- UUID: 004a3dea-b4d3-42dc-97ee-cbb733f288dc -->
+
+The documents herein define the custom parameters of the Kyber Instance of the Distribution Reward Primitive, if any.
+
+###### A.6.1.1.4.2.5.1.2.10.2 - Operational Process Definition [Core]  <!-- UUID: c9318928-b158-4909-a258-ea12b1cb2403 -->
+
+The documents herein define the process for the ongoing management of the Kyber Instance of the Distribution Reward Primitive.
+
+###### A.6.1.1.4.2.5.1.2.10.2.1 - Routine Protocol [Core]  <!-- UUID: 1a1c4089-43c6-456c-a2a0-58c8e30f8dc4 -->
+
+This document defines the protocol for routine ongoing management of the Kyber Instance. This Instance inherits the base class of operational logic defined in [A.2.2.9.1.2.4.1 - Routine Protocol](c2abdd22-fe0f-489e-b281-450e066db701), subject to the qualifications specified in [A.2.2.9.1.2.1.3.3.1 - Near-Term Process](05fb732b-de55-4886-81a7-7c5d4c13d2d2).
+
+Modifications to the base operational logic automatically propagate to this Instance. In future iterations of the Skybase Artifact, a version of the full process definition customized to Skybase will be included herein.
+
+###### A.6.1.1.4.2.5.1.2.10.2.1.1 - Agent Customizations [Core]  <!-- UUID: b03afeac-fd8b-4a8a-b713-477de6d825a7 -->
+
+The Prime Agent may define Instance-specific customization of the routine protocol to extend the baseline functionality defined in the Sky Core Atlas. This can include custom routines or processes layered on top of the inherited Sky Core logic. Any extensions must remain fully aligned with the requirements specified in the Sky Core Atlas. This document defines those customizations, if any.
+
+[No customization presently.]
+
+###### A.6.1.1.4.2.5.1.2.10.2.2 - Non-Routine Protocol [Core]  <!-- UUID: b4a55a71-79ef-4118-8623-518400360a32 -->
+
+The documents herein define the protocol for non-routine ongoing management of the Kyber Instance of this Distribution Reward Primitive.
+
+###### A.6.1.1.4.2.5.1.2.10.2.3 - Emergency Protocol [Core]  <!-- UUID: 294f365f-51e7-414e-8d57-81d5b8797623 -->
+
+The documents herein define the protocol for handling emergency situations in the ongoing management of the Kyber Instance of this Distribution Reward Primitive.
+
+###### A.6.1.1.4.2.5.1.2.10.3 - Data Repository [Core]  <!-- UUID: f9b0b513-0051-4297-9131-ddb60640d203 -->
+
+The documents herein contain data relevant to the Kyber Instance of the Distribution Reward Primitive.
+
+###### A.6.1.1.4.2.5.1.2.10.3.1 - Initial Planning [Core]  <!-- UUID: 7b6d6d5e-6256-4964-af7b-9abfeaceb732 -->
+
+The materials associated with initial planning of the Invocation of this Instance are contained herein.
+
+###### A.6.1.1.4.2.5.1.2.10.3.2 - Operational GovOps Review [Core]  <!-- UUID: 9ead2507-fdaa-45d6-9f4d-d5783f425d39 -->
+
+The materials associated with Operational GovOps Review during the Invocation of this Instance are contained herein.
+
+###### A.6.1.1.4.2.5.1.2.10.3.3 - Artifact Edit Proposal [Core]  <!-- UUID: 763c9fbd-91ec-4d1b-bbfc-5690f4ae2989 -->
+
+The materials associated with preparing the Artifact Edit Proposal during the Invocation of this Instance are contained herein.
+
+###### A.6.1.1.4.2.5.1.2.10.3.4 - Distribution Reward Payments [Active Data Controller]  <!-- UUID: a8d0e137-14f9-4f76-8ea1-eb525a9682cc -->
+
+The Distribution Reward payments for the Kyber Instance of the Distribution Reward Primitive are defined as Active Data.
+
+The Active Data is updated as follows:
+
+- The Responsible Party is Operational GovOps.
+- The Update Process must follow the protocol for ‘Direct Edit’.
+
+###### A.6.1.1.4.2.5.1.2.10.3.4.0.6.1 - List Of Distribution Reward Payments [Active Data]  <!-- UUID: a3db4319-a749-4dee-a2a8-411cc9b83b05 -->
+
+The Distribution Reward Payments are:
+
+###### A.6.1.1.4.2.5.1.2.10.3.5 - Third Party Partner Payment Addresses And Transaction Records [Active Data Controller]  <!-- UUID: baddbc1d-cff5-4bc6-b3c2-f59db47e07bb -->
+
+This Document records information pertaining to Skybase's payments to the Third Party Partner associated with this Instance. This information is defined as Active Data.
+
+The Active Data is updated as follows:
+
+- The Responsible Party is Operational GovOps.
+- The Update Process must follow the protocol for ‘Direct Edit’.
+
+###### A.6.1.1.4.2.5.1.2.10.3.5.0.6.1 - Payment Details Per Reward Period [Active Data]  <!-- UUID: da19af0b-0eaa-489d-bf80-d1dae799d940 -->
+
+The payment details consist of a table where each entry represents a single payment. Each entry has the following fields:
+
+- Reward Period
+- Payee
+- Payment Address
+- Amount Paid
+- Transaction Hash
+- Transaction Date
+
+###### A.6.1.1.4.2.5.1.2.10.3.5.0.6.2 - Third Party Partner Payment Addresses [Active Data]  <!-- UUID: 3b8bc7f6-7b4c-4e46-ae98-4694cff0ace8 -->
 
 The payment address of this Third Party Partner will be defined in a future iteration of the Skybase Artifact.
 

--- a/content/A.6.1.1.5 - Obex.md
+++ b/content/A.6.1.1.5 - Obex.md
@@ -1455,8 +1455,11 @@ The documents herein defines roles (Admin, Relayer, ALM Controller and Freezer) 
 
 The admin role (DEFAULT_ADMIN_ROLE) is the role that can grant and revoke any role, including itself and all other roles defined in the contract. The admin role is also used for general admin functions in all contracts. This role is fully controlled by Sky Governance via the Obex Proxy.
 
-`constructor(address admin) {
-_grantRole(DEFAULT_ADMIN_ROLE, admin);`
+```solidity
+constructor(address admin_) {
+    _grantRole(DEFAULT_ADMIN_ROLE, admin_);
+}
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.1.2 - Relayer Role [Core]  <!-- UUID: 0a8458ff-499e-4ac6-85a3-6ce200df18ae -->
 
@@ -1486,7 +1489,7 @@ The documents herein define the operations performed by the admin role (see [A.6
 
 The documents herein define the steps for an admin to specify which address should receive newly minted tokens on a particular destination domain.
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.1.1.1 - Call setMintRecipient Function [Core]  <!-- UUID: 05134536-1b5a-488f-8c82-a9a1aa6ea836 -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.1.1.1 - setMintRecipient Function [Core]  <!-- UUID: 05134536-1b5a-488f-8c82-a9a1aa6ea836 -->
 
 Only an operator with the admin role is able to set the mint recipient for a destination domain. To do so, they must call the `setMintRecipient` function on the Controller contract on mainnet providing the destination domain and the mint recipient address. Calling this function will carry out the following actions:
 
@@ -1494,15 +1497,17 @@ Only an operator with the admin role is able to set the mint recipient for a des
 - The contract will set the selected mint recipient for the specified destination domain.
 - The contract will emit a `MintRecipientSet` event to the blockchain logs.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function setMintRecipient(uint32 destinationDomain, bytes32 mintRecipient) external`
+```solidity
+function setMintRecipient(uint32 destinationDomain, bytes32 mintRecipient) external
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.2.1.1.2 - Set LayerZero Recipient [Core]  <!-- UUID: 27f7da97-2cf4-4d32-81e9-c1ef7b8f0199 -->
 
 The documents herein define the steps for an admin to specify which address should receive LayerZero messages on a particular destination endpoint.
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.1.2.1 - Call setLayerZeroRecipient Function [Core]  <!-- UUID: 54c019d8-ae0a-4c1c-9f05-1192d7b1cefb -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.1.2.1 - setLayerZeroRecipient Function [Core]  <!-- UUID: 54c019d8-ae0a-4c1c-9f05-1192d7b1cefb -->
 
 Only an operator with the admin role is able to set the LayerZero recipient for a destination endpoint. To do so, they must call the `setLayerZeroRecipient` function on the Controller contract on mainnet, providing the destination endpoint ID and the recipient address. Calling this function will carry out the following actions:
 
@@ -1510,15 +1515,17 @@ Only an operator with the admin role is able to set the LayerZero recipient for 
 - The contract will set the selected LayerZero recipient for the specified destination endpoint.
 - The contract will emit a `LayerZeroRecipientSet` event to the blockchain logs.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function setLayerZeroRecipient(uint32 destinationEndpointId, bytes32 layerZeroRecipient) external`
+```solidity
+function setLayerZeroRecipient(uint32 destinationEndpointId, bytes32 layerZeroRecipient) external
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.2.1.1.3 - Set Maximum Slippage [Core]  <!-- UUID: c25f736d-c806-4287-a5ee-9ef81f8e0ab7 -->
 
 The documents herein define the steps for an admin to set the maximum allowed slippage for a specific pool.
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.1.3.1 - Call setMaximumSlippage Function [Core]  <!-- UUID: 9926982e-5571-4108-9caa-88b4d8708d45 -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.1.3.1 - setMaxSlippage Function [Core]  <!-- UUID: 9926982e-5571-4108-9caa-88b4d8708d45 -->
 
 Only an operator with the admin role is able to set the maximum slippage for a pool. To do so, they must call the `setMaxSlippage` function on the Controller contract on mainnet, providing the pool address and the maximum slippage value. Calling this function will carry out the following actions:
 
@@ -1526,9 +1533,11 @@ Only an operator with the admin role is able to set the maximum slippage for a p
 - The contract will set the maximum slippage for the specified pool.
 - The contract will emit a `MaxSlippageSet` event to the blockchain logs.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function setMaxSlippage(address pool, uint256 maxSlippage) external`
+```solidity
+function setMaxSlippage(address pool, uint256 maxSlippage) external
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.2.1.2 - Relayer Functions [Core]  <!-- UUID: 04da1a02-47fb-4ecd-9b50-27daf99b6d6f -->
 
@@ -1542,7 +1551,7 @@ The documents herein define the operations that are performed to maintain the de
 
 The documents herein define the steps for a relayer to mint USDS from the Sky Allocation Vault to the Obex ALM Proxy.
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.1.1.1 - Call mintUSDS Function [Core]  <!-- UUID: e6313c89-b401-468d-882b-bf5e57d0182c -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.1.1.1 - mintUSDS Function [Core]  <!-- UUID: e6313c89-b401-468d-882b-bf5e57d0182c -->
 
 Only an operator with the relayer role is able to mint USDS. To do so, they must call the `mintUSDS` function on the Controller contract on mainnet with the amount of USDS that is required for minting. Calling this function will carry out the following actions:
 
@@ -1552,15 +1561,17 @@ Only an operator with the relayer role is able to mint USDS. To do so, they must
 - The contract will mint the required USDS into the buffer contract.
 - The contract will transfer the newly minted USDS from the buffer to the Proxy.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function mintUSDS(uint256 usdsAmount) external`
+```solidity
+function mintUSDS(uint256 usdsAmount) external
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.1.2 - Burn USDS [Core]  <!-- UUID: 1e27b007-ed34-4c15-9116-d62145572dce -->
 
 The documents herein define the steps for a relayer to return and then burn Obex’s USDS debt in the Sky Allocation Vault.
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.1.2.1 - Call burnUSDS Function [Core]  <!-- UUID: 9faf62a8-812c-4986-8133-5b3493634b9f -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.1.2.1 - burnUSDS Function [Core]  <!-- UUID: 9faf62a8-812c-4986-8133-5b3493634b9f -->
 
 Only an operator with the relayer role is able to repay vault debt and burn USDS. To do so, they must call the `burnUSDS` function of the Controller contract on mainnet with the amount of USDS that they wish to burn. Calling this function will carry out the following actions:
 
@@ -1569,9 +1580,11 @@ Only an operator with the relayer role is able to repay vault debt and burn USDS
 - The contract will transfer USDS from the proxy to the buffer.
 - The contract will burn the USDS from the buffer and `wipe` an equivalent amount from the vault's debt.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function burnUSDS(uint256 usdsAmount) external`
+```solidity
+function burnUSDS(uint256 usdsAmount) external
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.2 - ERC-20 Functions [Core]  <!-- UUID: 4d4dd524-bad6-424b-9d39-0e35f8f889b4 -->
 
@@ -1581,7 +1594,7 @@ The documents herein define the operations that are performed to transfer ERC-20
 
 The documents herein define the steps for a relayer to transfer ERC-20 tokens to a destination address.
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.2.1.1 - Call transferAsset Function [Core]  <!-- UUID: 77447d4a-137b-4b1c-b266-02ca8c678f61 -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.2.1.1 - transferAsset Function [Core]  <!-- UUID: 77447d4a-137b-4b1c-b266-02ca8c678f61 -->
 
 Only an operator with the relayer role is able to transfer ERC-20 assets. To do so, they must call the `transferAsset` function on the Controller contract on mainnet, providing the ERC20 asset address, the destination address, and the amount to transfer. Calling this function will carry out the following actions:
 
@@ -1589,9 +1602,11 @@ Only an operator with the relayer role is able to transfer ERC-20 assets. To do 
 - The contract will ensure the `RateLimits` allow for transferring the specified amount of the asset to the destination. If the transfer amount does not fall within the available Rate Limit, the transaction will revert.
 - The contract will execute the ERC-20 `transfer` function, sending the specified amount of the asset to the destination address.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function transferAsset(address asset, address destination, uint256 amount) external`
+```solidity
+function transferAsset(address asset, address destination, uint256 amount) external
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.3 - ERC-4626 Functions [Core]  <!-- UUID: 08d30ec2-c343-4176-aded-dce33e76d69c -->
 
@@ -1601,7 +1616,7 @@ The documents herein define the general Obex Liquidity Layer operational procedu
 
 The documents herein define the steps for a relayer to deposit assets from the ALM Proxy to an ERC-4626 vault to receive yield-bearing shares.
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.3.1.1 - Call depositERC4626 Function [Core]  <!-- UUID: 58edaa80-7dc0-4591-93fb-3552a2bb6a0b -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.3.1.1 - depositERC4626 Function [Core]  <!-- UUID: 58edaa80-7dc0-4591-93fb-3552a2bb6a0b -->
 
 Only an operator with the relayer role can deposit assets into an ERC-4626 vault. To do so, they must call the `depositERC4626` function on the Controller contract on mainnet, providing the vault token address and the amount of the underlying asset to deposit. The operation will only succeed if the ALM Proxy holds at least the amount of the underlying asset specified for deposit; otherwise, the transaction will revert. The rate limit configuration serves as whitelisting for vaults. Calling this function will carry out the following actions:
 
@@ -1610,15 +1625,17 @@ Only an operator with the relayer role can deposit assets into an ERC-4626 vault
 - The contract will approve the vault to spend the underlying asset from the ALM Proxy. The approval and deposit are both performed from the ALM Proxy address.
 - The contract will deposit the specified amount into the vault, and the ALM Proxy will receive the corresponding number of vault shares.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function depositERC4626(address token, uint256 amount) external returns (uint256 shares)`
+```solidity
+function depositERC4626(address token, uint256 amount) external returns (uint256 shares)
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.3.2 - Withdraw From ERC-4626 Vault [Core]  <!-- UUID: 3ea615ce-f2a9-4451-aed4-dd52c0703f5b -->
 
 The documents herein define the steps for a relayer to withdraw a specified amount of the underlying asset from an ERC-4626 vault to the ALM Proxy.
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.3.2.1 - Call withdrawERC4626 Function [Core]  <!-- UUID: d545d2f1-5973-4a93-889c-9d558ff79be7 -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.3.2.1 - withdrawERC4626 Function [Core]  <!-- UUID: d545d2f1-5973-4a93-889c-9d558ff79be7 -->
 
 Only an operator with the relayer role can withdraw assets from an ERC-4626 vault. To do so, they must call the `withdrawERC4626` function on the Controller contract on mainnet, providing the vault token address and the amount of the underlying asset to withdraw. The operation will only succeed if the ALM Proxy holds at least the amount of the underlying asset specified for withdrawal; otherwise, the transaction will revert. Calling this function will carry out the following actions:
 
@@ -1627,15 +1644,17 @@ Only an operator with the relayer role can withdraw assets from an ERC-4626 vaul
 - The contract will withdraw the specified amount from the vault, burning the necessary number of vault shares held by the ALM Proxy as part of the withdrawal process.
 - The withdrawn assets will be sent to the ALM Proxy.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function withdrawERC4626(address token, uint256 amount) external returns (uint256 shares)`
+```solidity
+function withdrawERC4626(address token, uint256 amount) external returns (uint256 shares)
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.3.3 - Redeem ERC-4626 Shares [Core]  <!-- UUID: 8e6a7981-7658-4c4e-ab87-aad8db8e215e -->
 
 The documents herein define the steps for a relayer to redeem vault shares for the underlying asset from an ERC-4626 vault, with the assets sent to the ALM Proxy.
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.3.3.1 - Call redeemERC4626 Function [Core]  <!-- UUID: 5e9546bb-fbb9-4f4f-92f6-5ba41dffb41f -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.3.3.1 - redeemERC4626 Function [Core]  <!-- UUID: 5e9546bb-fbb9-4f4f-92f6-5ba41dffb41f -->
 
 Only an operator with the relayer role can redeem vault shares for the underlying asset. To do so, they must call the `redeemERC4626` function on the Controller contract on mainnet, providing the number of shares to redeem. The address is the ALM Proxy acting as both the owner of the shares being redeemed and the receiver of the resulting assets. The operation will only succeed if the ALM Proxy holds at least the number of shares specified for redemption; otherwise, the transaction will revert. Calling this function will carry out the following actions:
 
@@ -1643,9 +1662,11 @@ Only an operator with the relayer role can redeem vault shares for the underlyin
 - The contract will redeem the specified number of shares from the vault, sending the resulting assets to the ALM Proxy.
 - After redemption, the contract will update the withdrawal rate limit based on the amount of assets received.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function redeemERC4626(address token, uint256 shares) external returns (uint256 assets)`
+```solidity
+function redeemERC4626(address token, uint256 shares) external returns (uint256 assets)
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.4 - ERC-7540 Functions [Core]  <!-- UUID: e1a57a43-7bac-4f32-b4cc-4de7c050a89b -->
 
@@ -1655,7 +1676,7 @@ The documents herein define the general Obex Liquidity Layer operational procedu
 
 The documents herein define the steps for a relayer to request and claim deposit of assets from the ALM Proxy to an ERC-7540 vault.
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.4.1.1 - Call requestDepositERC7540 Function [Core]  <!-- UUID: 134e3124-3ba1-43dc-a3e6-9347416f006b -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.4.1.1 - requestDepositERC7540 Function [Core]  <!-- UUID: 134e3124-3ba1-43dc-a3e6-9347416f006b -->
 
 Only an operator with the relayer role can request a deposit into an ERC-7540 vault. To do so, they must call the `requestDepositERC7540` function on the Controller contract on mainnet, providing the vault token address and the amount of the underlying asset to deposit. The operation will only succeed if the ALM Proxy holds at least the amount of the underlying asset specified for deposit; otherwise, the transaction will revert. The Rate Limit configuration serves as whitelisting for vaults. Calling this function will carry out the following actions:
 
@@ -1664,11 +1685,13 @@ Only an operator with the relayer role can request a deposit into an ERC-7540 va
 - The contract will approve the vault to spend the underlying asset from the ALM Proxy. The approval and deposit are both performed from the ALM Proxy address.
 - The contract will submit a deposit request to the vault. Shares will not be received immediately; they must be claimed in a separate step after the vault processes the deposit.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function requestDepositERC7540(address token, uint256 amount) external`
+```solidity
+function requestDepositERC7540(address token, uint256 amount) external
+```
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.4.1.2 - Call claimDepositERC7540 Function [Core]  <!-- UUID: 41f68822-0f26-4fb2-a805-587fc08abb3f -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.4.1.2 - claimDepositERC7540 Function [Core]  <!-- UUID: 41f68822-0f26-4fb2-a805-587fc08abb3f -->
 
 Only an operator with the relayer role can claim shares from an ERC-7540 vault after a deposit request. To do so, they must call the `claimDepositERC7540` function on the Controller contract on mainnet, providing the vault token address. Calling this function will carry out the following actions:
 
@@ -1676,15 +1699,17 @@ Only an operator with the relayer role can claim shares from an ERC-7540 vault a
 - The contract will determine the maximum number of shares that can be claimed by the ALM Proxy.
 - The contract will claim the shares from the vault, and the ALM Proxy will receive the corresponding number of vault shares.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function claimDepositERC7540(address token) external`
+```solidity
+function claimDepositERC7540(address token) external
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.4.2 - Redeem From ERC-7540 Vault [Core]  <!-- UUID: 6765a298-8ea7-4b1d-8d37-b3ccb069e12b -->
 
 The documents herein define the steps for a relayer to request and redeem vault shares for the underlying asset from an ERC-7540 vault, with the assets sent to the ALM Proxy.
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.4.2.1 - Call requestRedeemERC7540 Function [Core]  <!-- UUID: bd723808-6f03-41ed-9b19-72672d38dc36 -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.4.2.1 - requestRedeemERC7540 Function [Core]  <!-- UUID: bd723808-6f03-41ed-9b19-72672d38dc36 -->
 
 Only an operator with the relayer role can request the redemption of shares from an ERC-7540 vault. To do so, they must call the `requestRedeemERC7540` function on the Controller contract on mainnet, providing the vault token address and the number of shares to redeem. The rate limit configuration serves as whitelisting for vaults. Calling this function will carry out the following actions:
 
@@ -1692,11 +1717,13 @@ Only an operator with the relayer role can request the redemption of shares from
 - The contract will ensure the redemption amount is within the allowed rate limit for the specified vault.
 - The contract will submit a redemption request to the vault. Assets will not be received immediately; they must be claimed in a separate step after the vault processes the redemption.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function requestRedeemERC7540(address token, uint256 amount) external`
+```solidity
+function requestRedeemERC7540(address token, uint256 shares) external
+```
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.4.2.2 - Call claimRedeemERC7540 Function [Core]  <!-- UUID: 08474241-fee8-4ca3-95e8-564bd6676ea1 -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.4.2.2 - claimRedeemERC7540 Function [Core]  <!-- UUID: 08474241-fee8-4ca3-95e8-564bd6676ea1 -->
 
 Only an operator with the relayer role can claim assets from an ERC-7540 vault after a redemption request. To do so, they must call the `claimRedeemERC7540` function on the Controller contract on mainnet, providing the vault token address. Calling this function will carry out the following actions:
 
@@ -1704,9 +1731,11 @@ Only an operator with the relayer role can claim assets from an ERC-7540 vault a
 - The contract will determine the maximum amount of assets that can be claimed by the ALM Proxy.
 - The contract will claim the assets from the vault, and the ALM Proxy will receive the corresponding amount of underlying assets.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function claimRedeemERC7540(address token) external`
+```solidity
+function claimRedeemERC7540(address token) external
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.5 - Dai / USDS Functions [Core]  <!-- UUID: df1e38f3-5954-44d6-8500-6d26f03cc8da -->
 
@@ -1716,7 +1745,7 @@ The documents herein define the swap operations between Dai and USDS.
 
 The documents herein define a series of operations for an operator to `swap` USDS to Dai.
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.5.1.1 - Call swapUSDSToDAI Function [Core]  <!-- UUID: ed445f2b-9211-46fe-b79a-6e70cac7fec7 -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.5.1.1 - swapUSDSToDAI Function [Core]  <!-- UUID: ed445f2b-9211-46fe-b79a-6e70cac7fec7 -->
 
 Only an operator with the relayer role can swap USDS to Dai. To do so, they must call the `swapUSDSToDAI` function on the Controller contract on mainnet, providing the usdsAmount. The operation will only succeed if the Proxy holds enough USDS for the swap; otherwise, the transaction will revert. Calling this function will carry out the following actions:
 
@@ -1724,15 +1753,17 @@ Only an operator with the relayer role can swap USDS to Dai. To do so, they must
 - The contract will approve the DaiUsds migrator to spend the specified USDS amount from the Proxy.
 - The contract will swap USDS to Dai at a 1:1 ratio by calling the `usdsToDai` function on the migrator, sending the resulting DAI to the proxy.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function swapUSDSToDAI(uint256 usdsAmount) external`
+```solidity
+function swapUSDSToDAI(uint256 usdsAmount) external
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.5.2 - Swap Dai to USDS [Core]  <!-- UUID: d536a9fd-fa93-4909-ab75-17f3c4ccce3a -->
 
 The documents herein define a series of operations for an operator to `swap` Dai to USDS.
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.5.2.1 - Call swapDAIToUSDS Function [Core]  <!-- UUID: 3941f682-b9ae-483e-93a5-4c756388434e -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.5.2.1 - swapDAIToUSDS Function [Core]  <!-- UUID: 3941f682-b9ae-483e-93a5-4c756388434e -->
 
 Only an operator with the relayer role can swap Dai to USDS. To do so, they must call the `swapDAIToUSDS` function on the Controller contract on mainnet, providing the daiAmount. The operation will only succeed if the Proxy holds enough Dai for the swap; otherwise, the transaction will revert. Calling this function will carry out the following actions:
 
@@ -1740,9 +1771,11 @@ Only an operator with the relayer role can swap Dai to USDS. To do so, they must
 - The contract will approve the DaiUsds migrator to spend the specified Dai amount from the Proxy.
 - The contract will swap Dai to USDS at a 1:1 ratio by calling the `daiToUsds` function on the migrator, sending the resulting USDS to the proxy.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function swapDAIToUSDS(uint256 daiAmount) external`
+```solidity
+function swapDAIToUSDS(uint256 daiAmount) external
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.6 - PSM Functions [Core]  <!-- UUID: 8666d408-4c3a-4646-8cbf-d0752167dcd6 -->
 
@@ -1752,7 +1785,7 @@ The documents herein define the swap operations performed by the Obex Liquidity 
 
 The documents herein define a series of operations for an operator to `swap` USDS to USDC through the PSM.
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.6.1.1 - Call swapUSDSToUSDC Function [Core]  <!-- UUID: 0ec7c5be-32a2-4d3b-b856-71face6612a9 -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.6.1.1 - swapUSDSToUSDC Function [Core]  <!-- UUID: 0ec7c5be-32a2-4d3b-b856-71face6612a9 -->
 
 Only an operator with the relayer role can swap USDS to USDC via the PSM. To do so, they must call the `swapUSDSToUSDC` function on the Controller contract on mainnet, providing the usdcAmount (denominated in 1e6 precision to match PSM USDC handling). The operation will only succeed if the ALM Proxy holds at least the equivalent amount of USDS for the swap; otherwise, the transaction will revert. The rate limit configuration serves as whitelisting for swaps. Calling this function will carry out the following actions:
 
@@ -1764,15 +1797,17 @@ Only an operator with the relayer role can swap USDS to USDC via the PSM. To do 
 - The contract will approve the PSM to spend the Dai.
 - The contract will swap Dai to USDC at a 1:1 ratio with no fee via psm.buyGemNoFee, sending USDC to the proxy.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function swapUSDSToUSDC(uint256 usdcAmount) external`
+```solidity
+function swapUSDSToUSDC(uint256 usdcAmount) external
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.6.2 - Swap USDC To USDS [Core]  <!-- UUID: 17675b49-5767-47de-9ccf-e324b7bebec5 -->
 
 The documents herein define a series of operations for an operator to `swap` USDC to USDS through the PSM.
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.6.2.1 - Call swapUSDCToUSDS Function [Core]  <!-- UUID: f0117433-4568-4b4b-bed6-fce75f85939a -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.6.2.1 - swapUSDCToUSDS Function [Core]  <!-- UUID: f0117433-4568-4b4b-bed6-fce75f85939a -->
 
 Only an operator with the relayer role can swap USDC to USDS via the PSM. To do so, they must call the `swapUSDCToUSDS` function on the Controller contract on mainnet, providing the usdcAmount (denominated in 1e6 precision to match PSM USDC handling). The operation will only succeed if the ALM Proxy holds at least the amount of USDC specified for the swap; otherwise, the transaction will revert. The rate limit configuration serves as whitelisting for swaps. Calling this function will carry out the following actions:
 
@@ -1786,15 +1821,17 @@ Only an operator with the relayer role can swap USDC to USDS via the PSM. To do 
 - The contract will approve the daiUsds contract to spend the Dai amount from the ALM Proxy.
 - The contract will swap Dai to USDS at a 1:1 ratio via daiUsds, sending USDS to the proxy.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function swapUSDCToUSDS(uint256 usdcAmount) external`
+```solidity
+function swapUSDCToUSDS(uint256 usdcAmount) external
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.6.3 - Transfer Token Via LayerZero [Core]  <!-- UUID: 7f1746e3-9bc8-467f-97b8-72e4ee51ebfc -->
 
 The documents herein define the steps for a relayer to `transfer` a token via LayerZero to a destination endpoint, with the assets sent according to the configured recipient.
 
-###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.6.3.1 - Call transferTokenLayerZero Function [Core]  <!-- UUID: 04a8ecfb-e8b5-4994-b4f1-1fe99efd8dcd -->
+###### A.6.1.1.5.2.6.1.2.2.1.2.1.2.6.3.1 - transferTokenLayerZero Function [Core]  <!-- UUID: 04a8ecfb-e8b5-4994-b4f1-1fe99efd8dcd -->
 
 Only an operator with the relayer role can transfer tokens via LayerZero. To do so, they must call the `transferTokenLayerZero` function on the Controller contract on mainnet, providing the oftAddress, amount, and destinationEndpointId (payable for native fees). The operation will only succeed if the ALM Proxy holds sufficient tokens and fees; otherwise, the transaction will revert. Calling this function will carry out the following actions:
 
@@ -1805,9 +1842,11 @@ Only an operator with the relayer role can transfer tokens via LayerZero. To do 
 - The contract will quote the OFT receipt to set the minimum amount received.
 - The contract will quote the messaging fee and execute the send via proxy.doCallWithValue, passing the fee value.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function transferTokenLayerZero(address oftAddress, uint256 amount, uint32  destinationEndpointId) external payable`
+```solidity
+function transferTokenLayerZero(address oftAddress, uint256 amount, uint32 destinationEndpointId) external payable
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.3 - Rate Limit Management [Core]  <!-- UUID: 73da45c9-78eb-49f3-a1d5-593780e9d362 -->
 
@@ -1819,9 +1858,11 @@ Anyone can query the full rate limit data for a specific key. Calling this funct
 
 - The contract will return the stored RateLimitData struct from the _data mapping for the key.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function getRateLimitData(bytes32 key) external override view returns (RateLimitData memory)`
+```solidity
+function getRateLimitData(bytes32 key) external override view returns (RateLimitData memory)
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.3.2 - Set Rate Limit Data [Core]  <!-- UUID: 993bbc35-1692-4c1b-87b2-de5997e90bf5 -->
 
@@ -1832,11 +1873,15 @@ Only an operator with the admin role is able to set or update rate limit data fo
 - The contract will store the provided data in the _data mapping as a RateLimitData struct.
 - The contract will emit a RateLimitDataSet event with the key and provided values.
 
-The function calls are as follows:
+The function signatures are as follows:
 
-`function setRateLimitData(bytes32 key, uint256 maxAmount, uint256 slope, uint256 lastAmount, uint256 lastUpdated) public override onlyRole(DEFAULT_ADMIN_ROLE)
+```solidity
+function setRateLimitData(bytes32 key, uint256 maxAmount, uint256 slope, uint256 lastAmount, uint256 lastUpdated) public override onlyRole(DEFAULT_ADMIN_ROLE)
+```
 
-function setRateLimitData(bytes32 key, uint256 maxAmount, uint256 slope) external override`
+```solidity
+function setRateLimitData(bytes32 key, uint256 maxAmount, uint256 slope) external override
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.3.3 - Set Unlimited Rate Limit Data [Core]  <!-- UUID: 37aed332-50c8-4392-91be-095bd13139d1 -->
 
@@ -1844,9 +1889,11 @@ Only an operator with the admin role is able to set unlimited rate limit data fo
 
 - The contract will call setRateLimitData internally with type(uint256).max for maxAmount and lastAmount, 0 for slope, and the current block timestamp for lastUpdated.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function setUnlimitedRateLimitData(bytes32 key) external override`
+```solidity
+function setUnlimitedRateLimitData(bytes32 key) external override
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.3.4 - Get Current Rate Limit [Core]  <!-- UUID: f629bb8f-afb2-4bfc-b7fa-3f5fbaa2c2f9 -->
 
@@ -1856,9 +1903,11 @@ Anyone can query the current rate limit value for a specific key, accounting for
 - If maxAmount is type(uint256).max (unlimited case), the contract will return type(uint256).max.
 - Otherwise, the contract will calculate and return the minimum of (slope * time elapsed since lastUpdated + lastAmount) and maxAmount.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function getCurrentRateLimit(bytes32 key) public override view returns (uint256)`
+```solidity
+function getCurrentRateLimit(bytes32 key) public override view returns (uint256)
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.3.5 - Trigger Rate Limit Decrease [Core]  <!-- UUID: 2fc640dc-1f48-4167-a700-cb54f2cb1097 -->
 
@@ -1873,9 +1922,11 @@ Only an operator with the controller role can trigger a decrease in the rate lim
 - The contract will emit a RateLimitDecreaseTriggered event with the key, amountToDecrease, currentRateLimit, and newLimit.
 - The contract will return the newLimit.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function triggerRateLimitDecrease(bytes32 key, uint256 amountToDecrease) external override onlyRole(CONTROLLER) returns (uint256 newLimit)`
+```solidity
+function triggerRateLimitDecrease(bytes32 key, uint256 amountToDecrease) external override onlyRole(CONTROLLER) returns (uint256 newLimit)
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.1.4 - Instance Lifecycle Management [Core]  <!-- UUID: 2dde3f2b-925d-42a4-9fe1-0cb5bfd86855 -->
 
@@ -1901,9 +1952,11 @@ In the event of a compromised Relayer, the `FREEZER_ROLE` can call the function 
 - The contract will revoke the relayer role from the specified address.
 - The contract will emit a `RelayerRemoved(relayer)` event.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function removeRelayer(address relayer) external`
+```solidity
+function removeRelayer(address relayer) external
+```
 
 ###### A.6.1.1.5.2.6.1.2.2.3.2 - Redeem All Mainnet Positions [Core]  <!-- UUID: 10597c85-6ce2-4364-a83b-e2d3c93c45c7 -->
 
@@ -1915,7 +1968,9 @@ In order to withdraw all ERC-4626 balances, the operator must call the `redeemER
 
 The function call is as follows:
 
-`function redeemERC4626(address(token), token.balanceOf(address(proxy)))`
+```solidity
+redeemERC4626(address(token), token.balanceOf(address(proxy)))
+```
 
 For more detailed instructions on the code to execute this, see [A.6.1.1.5.2.6.1.2.2.1.2.1.2.3 - ERC-4626 Functions](08d30ec2-c343-4176-aded-dce33e76d69c).
 
@@ -1925,7 +1980,9 @@ This document defines the action that should be performed by an operator if ther
 
 The function call is as follows:
 
-`function swapUSDCToUSDS(usdc.balanceOf(address(proxy))`
+```solidity
+swapUSDCToUSDS(usdc.balanceOf(address(proxy)))
+```
 
 For more detailed instructions on the code to execute this see [A.6.1.1.5.2.6.1.2.2.1.2.1.2.6.2 - Swap USDC To USDS](17675b49-5767-47de-9ccf-e324b7bebec5).
 
@@ -1935,7 +1992,9 @@ This document defines the action that should be performed if there is a need to 
 
 The function call is as follows:
 
-`function burnUSDS(usds.balanceOf(address(proxy))`
+```solidity
+burnUSDS(usds.balanceOf(address(proxy)))
+```
 
 More detailed instructions on the code to execute this, see [A.6.1.1.5.2.6.1.2.2.1.2.1.2.1.2 - Burn USDS](1e27b007-ed34-4c15-9116-d62145572dce).
 
@@ -2040,7 +2099,7 @@ The documents herein contain operational procedures or monitoring requirements u
 
 The documents herein define the steps for a relayer to redeem vault shares from Maple.
 
-###### A.6.1.1.5.2.6.1.3.1.1.1.3.1.1 - Call RequestMapleRedemption Function [Core]  <!-- UUID: fd047e05-3239-434b-a5d8-81cd72ada783 -->
+###### A.6.1.1.5.2.6.1.3.1.1.1.3.1.1 - requestMapleRedemption Function [Core]  <!-- UUID: fd047e05-3239-434b-a5d8-81cd72ada783 -->
 
 Only an operator with the relayer role can request the redemption of shares from Maple. To do so, they must call the `requestMapleRedemption` function on the Controller contract on mainnet, providing the Maple token address and the number of shares to request. All Maple redemption operations are performed on behalf of the ALM Proxy and the destination address is always set to the proxy by the contract. Calling this function will carry out the following actions:
 
@@ -2048,11 +2107,13 @@ Only an operator with the relayer role can request the redemption of shares from
 - The contract will ensure the redemption amount is within the allowed rate limit for the specified vault and decrease the rate limit for the redemption amount.
 - The contract will submit a redemption request to the vault. Assets will not be received immediately; they must be claimed in a separate step after the vault processes the redemption.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function requestMapleRedemption(address mapleToken, uint256 shares) external`
+```solidity
+function requestMapleRedemption(address mapleToken, uint256 shares) external
+```
 
-###### A.6.1.1.5.2.6.1.3.1.1.1.3.1.2 - Call CancelMapleRedemption Function [Core]  <!-- UUID: 7378e3fb-3c6a-4ea4-8e01-c6b84658944d -->
+###### A.6.1.1.5.2.6.1.3.1.1.1.3.1.2 - cancelMapleRedemption Function [Core]  <!-- UUID: 7378e3fb-3c6a-4ea4-8e01-c6b84658944d -->
 
 Only an operator with the relayer role can cancel a previously requested redemption of shares from Maple. To do so, they must call the `cancelMapleRedemption` function on the Controller contract on mainnet, providing the Maple token address and the number of shares to cancel. All Maple cancellations of redemption operations are performed on behalf of the ALM Proxy. Calling this function will carry out the following actions:
 
@@ -2060,9 +2121,11 @@ Only an operator with the relayer role can cancel a previously requested redempt
 - The contract will check that a rate limit exists for the asset. If no rate limit exists the transaction will revert.
 - The contract will submit a cancellation request to the vault, removing the specified number of shares from the pending redemption.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function cancelMapleRedemption(address mapleToken, uint256 shares) external`
+```solidity
+function cancelMapleRedemption(address mapleToken, uint256 shares) external
+```
 
 ##### A.6.1.1.5.2.6.1.4 - Completed Instances [Core]  <!-- UUID: 6b16b0d6-a5a1-44da-a95d-e62d38a35ade -->
 

--- a/content/A.6.1.1.6 - Pattern.md
+++ b/content/A.6.1.1.6 - Pattern.md
@@ -1391,8 +1391,11 @@ The documents herein define roles (Admin, Relayer, ALM Controller, and Freezer) 
 
 The admin role (DEFAULT_ADMIN_ROLE) is the role that can grant and revoke any role, including itself and all other roles defined in the contract. The admin role is also used for general admin functions in all contracts. This role is fully controlled by Sky Governance via the Pattern Proxy.
 
-`constructor(address admin) {
-_grantRole(DEFAULT_ADMIN_ROLE, admin);`
+```solidity
+constructor(address admin_) {
+    _grantRole(DEFAULT_ADMIN_ROLE, admin_);
+}
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.1.2 - Relayer Role [Core]  <!-- UUID: 905e342b-8dca-4fbc-8673-f6fabb6b29fd -->
 
@@ -1422,7 +1425,7 @@ The documents herein define the operations performed by the admin role (see [A.6
 
 The documents herein define the steps for an admin to specify which address should receive newly minted tokens on a particular destination domain.
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.1.1.1 - Call setMintRecipient Function [Core]  <!-- UUID: 929818fb-10b0-4520-ba00-5bc2f46815ed -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.1.1.1 - setMintRecipient Function [Core]  <!-- UUID: 929818fb-10b0-4520-ba00-5bc2f46815ed -->
 
 Only an operator with the admin role is able to set the mint recipient for a destination domain. To do so, they must call the `setMintRecipient` function on the Controller contract on mainnet providing the destination domain and the mint recipient address. Calling this function will carry out the following actions:
 
@@ -1430,15 +1433,17 @@ Only an operator with the admin role is able to set the mint recipient for a des
 - The contract will set the selected mint recipient for the specified destination domain.
 - The contract will emit a `MintRecipientSet` event to the blockchain logs.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function setMintRecipient(uint32 destinationDomain, bytes32 mintRecipient) external`
+```solidity
+function setMintRecipient(uint32 destinationDomain, bytes32 mintRecipient) external
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.2.1.1.2 - Set LayerZero Recipient [Core]  <!-- UUID: 8666edaa-5bd6-4c13-9d3b-5854e90583cb -->
 
 The documents herein define the steps for an admin to specify which address should receive LayerZero messages on a particular destination endpoint.
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.1.2.1 - Call setLayerZeroRecipient Function [Core]  <!-- UUID: 0bc584c7-53da-47ee-9e7f-7514076e5fb0 -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.1.2.1 - setLayerZeroRecipient Function [Core]  <!-- UUID: 0bc584c7-53da-47ee-9e7f-7514076e5fb0 -->
 
 Only an operator with the admin role is able to set the LayerZero recipient for a destination endpoint. To do so, they must call the `setLayerZeroRecipient` function on the Controller contract on mainnet, providing the destination endpoint ID and the recipient address. Calling this function will carry out the following actions:
 
@@ -1446,15 +1451,17 @@ Only an operator with the admin role is able to set the LayerZero recipient for 
 - The contract will set the selected LayerZero recipient for the specified destination endpoint.
 - The contract will emit a `LayerZeroRecipientSet` event to the blockchain logs.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function setLayerZeroRecipient(uint32 destinationEndpointId, bytes32 layerZeroRecipient) external`
+```solidity
+function setLayerZeroRecipient(uint32 destinationEndpointId, bytes32 layerZeroRecipient) external
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.2.1.1.3 - Set Maximum Slippage [Core]  <!-- UUID: 829d2426-0bd7-44cb-b1c3-b9958706e1b6 -->
 
 The documents herein define the steps for an admin to set the maximum allowed slippage for a specific pool.
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.1.3.1 - Call setMaximumSlippage Function [Core]  <!-- UUID: 1d54c38f-02a3-4f15-b101-d23861967337 -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.1.3.1 - setMaxSlippage Function [Core]  <!-- UUID: 1d54c38f-02a3-4f15-b101-d23861967337 -->
 
 Only an operator with the admin role is able to set the maximum slippage for a pool. To do so, they must call the `setMaxSlippage` function on the Controller contract on mainnet, providing the pool address and the maximum slippage value. Calling this function will carry out the following actions:
 
@@ -1462,9 +1469,11 @@ Only an operator with the admin role is able to set the maximum slippage for a p
 - The contract will set the maximum slippage for the specified pool.
 - The contract will emit a `MaxSlippageSet` event to the blockchain logs.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function setMaxSlippage(address pool, uint256 maxSlippage) external`
+```solidity
+function setMaxSlippage(address pool, uint256 maxSlippage) external
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.2.1.2 - Relayer Functions [Core]  <!-- UUID: 6607a910-567f-4331-9edc-e8f5013f93fb -->
 
@@ -1478,7 +1487,7 @@ The documents herein define the operations that are performed to maintain the de
 
 The documents herein define the steps for a relayer to mint USDS from the Sky Allocation Vault to the Pattern ALM Proxy.
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.1.1.1 - Call mintUSDS Function [Core]  <!-- UUID: e58f4b54-eae5-4b7c-a6b5-68406b5b50b7 -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.1.1.1 - mintUSDS Function [Core]  <!-- UUID: e58f4b54-eae5-4b7c-a6b5-68406b5b50b7 -->
 
 Only an operator with the relayer role is able to mint USDS. To do so, they must call the `mintUSDS` function on the Controller contract on mainnet with the amount of USDS that is required for minting. Calling this function will carry out the following actions:
 
@@ -1488,15 +1497,17 @@ Only an operator with the relayer role is able to mint USDS. To do so, they must
 - The contract will mint the required USDS into the buffer contract.
 - The contract will transfer the newly minted USDS from the buffer to the Proxy.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function mintUSDS(uint256 usdsAmount) external`
+```solidity
+function mintUSDS(uint256 usdsAmount) external
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.1.2 - Burn USDS [Core]  <!-- UUID: 886d04ba-23c3-45fb-ac5d-044288a621e1 -->
 
 The documents herein define the steps for a relayer to return and then burn Pattern's USDS debt in the Sky Allocation Vault.
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.1.2.1 - Call burnUSDS Function [Core]  <!-- UUID: b974ebda-d402-456a-8b4d-1ea805ac7be0 -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.1.2.1 - burnUSDS Function [Core]  <!-- UUID: b974ebda-d402-456a-8b4d-1ea805ac7be0 -->
 
 Only an operator with the relayer role is able to repay vault debt and burn USDS. To do so, they must call the `burnUSDS` function of the Controller contract on mainnet with the amount of USDS that they wish to burn. Calling this function will carry out the following actions:
 
@@ -1505,9 +1516,11 @@ Only an operator with the relayer role is able to repay vault debt and burn USDS
 - The contract will transfer USDS from the proxy to the buffer.
 - The contract will burn the USDS from the buffer and `wipe` an equivalent amount from the vault's debt.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function burnUSDS(uint256 usdsAmount) external`
+```solidity
+function burnUSDS(uint256 usdsAmount) external
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.2 - ERC-20 Functions [Core]  <!-- UUID: dfc76ebc-2a7e-453f-8d9f-e2c380af3083 -->
 
@@ -1517,7 +1530,7 @@ The documents herein define the operations that are performed to transfer ERC-20
 
 The documents herein define the steps for a relayer to transfer ERC-20 tokens to a destination address.
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.2.1.1 - Call transferAsset Function [Core]  <!-- UUID: 530a40e2-8322-44ff-b2ce-4ea0821a8b80 -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.2.1.1 - transferAsset Function [Core]  <!-- UUID: 530a40e2-8322-44ff-b2ce-4ea0821a8b80 -->
 
 Only an operator with the relayer role is able to transfer ERC-20 assets. To do so, they must call the `transferAsset` function on the Controller contract on mainnet, providing the ERC20 asset address, the destination address, and the amount to transfer. Calling this function will carry out the following actions:
 
@@ -1525,9 +1538,11 @@ Only an operator with the relayer role is able to transfer ERC-20 assets. To do 
 - The contract will ensure the `RateLimits` allow for transferring the specified amount of the asset to the destination. If the transfer amount does not fall within the available Rate Limit, the transaction will revert.
 - The contract will execute the ERC-20 `transfer` function, sending the specified amount of the asset to the destination address.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function transferAsset(address asset, address destination, uint256 amount) external`
+```solidity
+function transferAsset(address asset, address destination, uint256 amount) external
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.3 - ERC-4626 Functions [Core]  <!-- UUID: c6dcf1ab-9861-4a41-9edc-ea79b705db2d -->
 
@@ -1537,7 +1552,7 @@ The documents herein define the general Pattern Liquidity Layer operational proc
 
 The documents herein define the steps for a relayer to deposit assets from the ALM Proxy to an ERC-4626 vault to receive yield-bearing shares.
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.3.1.1 - Call depositERC4626 Function [Core]  <!-- UUID: 04ac423a-ef3a-42a2-87de-745da9afded3 -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.3.1.1 - depositERC4626 Function [Core]  <!-- UUID: 04ac423a-ef3a-42a2-87de-745da9afded3 -->
 
 Only an operator with the relayer role can deposit assets into an ERC-4626 vault. To do so, they must call the `depositERC4626` function on the Controller contract on mainnet, providing the vault token address and the amount of the underlying asset to deposit. The operation will only succeed if the ALM Proxy holds at least the amount of the underlying asset specified for deposit; otherwise, the transaction will revert. The rate limit configuration serves as whitelisting for vaults. Calling this function will carry out the following actions:
 
@@ -1546,15 +1561,17 @@ Only an operator with the relayer role can deposit assets into an ERC-4626 vault
 - The contract will approve the vault to spend the underlying asset from the ALM Proxy. The approval and deposit are both performed from the ALM Proxy address.
 - The contract will deposit the specified amount into the vault, and the ALM Proxy will receive the corresponding number of vault shares.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function depositERC4626(address token, uint256 amount) external returns (uint256 shares)`
+```solidity
+function depositERC4626(address token, uint256 amount) external returns (uint256 shares)
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.3.2 - Withdraw From ERC-4626 Vault [Core]  <!-- UUID: 788ff656-5797-41f3-ac17-38c88e690cc5 -->
 
 The documents herein define the steps for a relayer to withdraw a specified amount of the underlying asset from an ERC-4626 vault to the ALM Proxy.
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.3.2.1 - Call withdrawERC4626 Function [Core]  <!-- UUID: 40875283-48ec-48f0-8b61-e45d33f976ab -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.3.2.1 - withdrawERC4626 Function [Core]  <!-- UUID: 40875283-48ec-48f0-8b61-e45d33f976ab -->
 
 Only an operator with the relayer role can withdraw assets from an ERC-4626 vault. To do so, they must call the `withdrawERC4626` function on the Controller contract on mainnet, providing the vault token address and the amount of the underlying asset to withdraw. The operation will only succeed if the ALM Proxy holds at least the amount of the underlying asset specified for withdrawal; otherwise, the transaction will revert. Calling this function will carry out the following actions:
 
@@ -1563,15 +1580,17 @@ Only an operator with the relayer role can withdraw assets from an ERC-4626 vaul
 - The contract will withdraw the specified amount from the vault, burning the necessary number of vault shares held by the ALM Proxy as part of the withdrawal process.
 - The withdrawn assets will be sent to the ALM Proxy.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function withdrawERC4626(address token, uint256 amount) external returns (uint256 shares)`
+```solidity
+function withdrawERC4626(address token, uint256 amount) external returns (uint256 shares)
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.3.3 - Redeem ERC-4626 Shares [Core]  <!-- UUID: 7582c5d2-205c-4ae0-8190-ae583a3db138 -->
 
 The documents herein define the steps for a relayer to redeem vault shares for the underlying asset from an ERC-4626 vault, with the assets sent to the ALM Proxy.
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.3.3.1 - Call redeemERC4626 Function [Core]  <!-- UUID: 037d3def-39bc-4aaf-9c3d-69fb86245f35 -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.3.3.1 - redeemERC4626 Function [Core]  <!-- UUID: 037d3def-39bc-4aaf-9c3d-69fb86245f35 -->
 
 Only an operator with the relayer role can redeem vault shares for the underlying asset. To do so, they must call the `redeemERC4626` function on the Controller contract on mainnet, providing the number of shares to redeem. The address is the ALM Proxy acting as both the owner of the shares being redeemed and the receiver of the resulting assets. The operation will only succeed if the ALM Proxy holds at least the number of shares specified for redemption; otherwise, the transaction will revert. Calling this function will carry out the following actions:
 
@@ -1579,9 +1598,11 @@ Only an operator with the relayer role can redeem vault shares for the underlyin
 - The contract will redeem the specified number of shares from the vault, sending the resulting assets to the ALM Proxy.
 - After redemption, the contract will update the withdrawal rate limit based on the amount of assets received.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function redeemERC4626(address token, uint256 shares) external returns (uint256 assets)`
+```solidity
+function redeemERC4626(address token, uint256 shares) external returns (uint256 assets)
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.4 - ERC-7540 Functions [Core]  <!-- UUID: f11f72f7-5f70-43e0-ad48-1b3285211284 -->
 
@@ -1591,7 +1612,7 @@ The documents herein define the general Pattern Liquidity Layer operational proc
 
 The documents herein define the steps for a relayer to request and claim deposit of assets from the ALM Proxy to an ERC-7540 vault.
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.4.1.1 - Call requestDepositERC7540 Function [Core]  <!-- UUID: 138b2674-60c1-4a5c-925a-e30956299119 -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.4.1.1 - requestDepositERC7540 Function [Core]  <!-- UUID: 138b2674-60c1-4a5c-925a-e30956299119 -->
 
 Only an operator with the relayer role can request a deposit into an ERC-7540 vault. To do so, they must call the `requestDepositERC7540` function on the Controller contract on mainnet, providing the vault token address and the amount of the underlying asset to deposit. The operation will only succeed if the ALM Proxy holds at least the amount of the underlying asset specified for deposit; otherwise, the transaction will revert. The Rate Limit configuration serves as whitelisting for vaults. Calling this function will carry out the following actions:
 
@@ -1600,11 +1621,13 @@ Only an operator with the relayer role can request a deposit into an ERC-7540 va
 - The contract will approve the vault to spend the underlying asset from the ALM Proxy. The approval and deposit are both performed from the ALM Proxy address.
 - The contract will submit a deposit request to the vault. Shares will not be received immediately; they must be claimed in a separate step after the vault processes the deposit.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function requestDepositERC7540(address token, uint256 amount) external`
+```solidity
+function requestDepositERC7540(address token, uint256 amount) external
+```
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.4.1.2 - Call claimDepositERC7540 Function [Core]  <!-- UUID: fccd0af9-6156-400e-bb4b-27a9d4fca711 -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.4.1.2 - claimDepositERC7540 Function [Core]  <!-- UUID: fccd0af9-6156-400e-bb4b-27a9d4fca711 -->
 
 Only an operator with the relayer role can claim shares from an ERC-7540 vault after a deposit request. To do so, they must call the `claimDepositERC7540` function on the Controller contract on mainnet, providing the vault token address. Calling this function will carry out the following actions:
 
@@ -1612,15 +1635,17 @@ Only an operator with the relayer role can claim shares from an ERC-7540 vault a
 - The contract will determine the maximum number of shares that can be claimed by the ALM Proxy.
 - The contract will claim the shares from the vault, and the ALM Proxy will receive the corresponding number of vault shares.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function claimDepositERC7540(address token) external`
+```solidity
+function claimDepositERC7540(address token) external
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.4.2 - Redeem From ERC-7540 Vault [Core]  <!-- UUID: b46a85df-ba8e-482a-bcde-b61f2b520190 -->
 
 The documents herein define the steps for a relayer to request and redeem vault shares for the underlying asset from an ERC-7540 vault, with the assets sent to the ALM Proxy.
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.4.2.1 - Call requestRedeemERC7540 Function [Core]  <!-- UUID: e637cc53-2243-483f-afa2-d3e92a3365fd -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.4.2.1 - requestRedeemERC7540 Function [Core]  <!-- UUID: e637cc53-2243-483f-afa2-d3e92a3365fd -->
 
 Only an operator with the relayer role can request the redemption of shares from an ERC-7540 vault. To do so, they must call the `requestRedeemERC7540` function on the Controller contract on mainnet, providing the vault token address and the number of shares to redeem. The rate limit configuration serves as whitelisting for vaults. Calling this function will carry out the following actions:
 
@@ -1628,11 +1653,13 @@ Only an operator with the relayer role can request the redemption of shares from
 - The contract will ensure the redemption amount is within the allowed rate limit for the specified vault.
 - The contract will submit a redemption request to the vault. Assets will not be received immediately; they must be claimed in a separate step after the vault processes the redemption.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function requestRedeemERC7540(address token, uint256 shares) external`
+```solidity
+function requestRedeemERC7540(address token, uint256 shares) external
+```
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.4.2.2 - Call claimRedeemERC7540 Function [Core]  <!-- UUID: 0c3a819b-f93f-4565-948f-7d9147cfe9d8 -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.4.2.2 - claimRedeemERC7540 Function [Core]  <!-- UUID: 0c3a819b-f93f-4565-948f-7d9147cfe9d8 -->
 
 Only an operator with the relayer role can claim assets from an ERC-7540 vault after a redemption request. To do so, they must call the `claimRedeemERC7540` function on the Controller contract on mainnet, providing the vault token address. Calling this function will carry out the following actions:
 
@@ -1640,9 +1667,11 @@ Only an operator with the relayer role can claim assets from an ERC-7540 vault a
 - The contract will determine the maximum amount of assets that can be claimed by the ALM Proxy.
 - The contract will claim the assets from the vault, and the ALM Proxy will receive the corresponding amount of underlying assets.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function claimRedeemERC7540(address token) external`
+```solidity
+function claimRedeemERC7540(address token) external
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.5 - Dai / USDS Functions [Core]  <!-- UUID: 918d2721-5fea-4b89-a134-56de5146aa5c -->
 
@@ -1652,7 +1681,7 @@ The documents herein define the swap operations between Dai and USDS.
 
 The documents herein define a series of operations for an operator to `swap` USDS to Dai.
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.5.1.1 - Call swapUSDSToDAI Function [Core]  <!-- UUID: b28a88b4-bb7f-4f7b-a538-cb394ce6ce23 -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.5.1.1 - swapUSDSToDAI Function [Core]  <!-- UUID: b28a88b4-bb7f-4f7b-a538-cb394ce6ce23 -->
 
 Only an operator with the relayer role can swap USDS to Dai. To do so, they must call the `swapUSDSToDAI` function on the Controller contract on mainnet, providing the usdsAmount. The operation will only succeed if the Proxy holds enough USDS for the swap; otherwise, the transaction will revert. Calling this function will carry out the following actions:
 
@@ -1660,15 +1689,17 @@ Only an operator with the relayer role can swap USDS to Dai. To do so, they must
 - The contract will approve the DaiUsds migrator to spend the specified USDS amount from the Proxy.
 - The contract will swap USDS to Dai at a 1:1 ratio by calling the `usdsToDai` function on the migrator, sending the resulting DAI to the proxy.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function swapUSDSToDAI(uint256 usdsAmount) external`
+```solidity
+function swapUSDSToDAI(uint256 usdsAmount) external
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.5.2 - Swap Dai to USDS [Core]  <!-- UUID: 76a9ada0-0697-4201-8b3b-621063b3554b -->
 
 The documents herein define a series of operations for an operator to `swap` Dai to USDS.
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.5.2.1 - Call swapDAIToUSDS Function [Core]  <!-- UUID: 06ba856a-91a7-43b5-b4d7-9f392df360d4 -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.5.2.1 - swapDAIToUSDS Function [Core]  <!-- UUID: 06ba856a-91a7-43b5-b4d7-9f392df360d4 -->
 
 Only an operator with the relayer role can swap Dai to USDS. To do so, they must call the `swapDAIToUSDS` function on the Controller contract on mainnet, providing the daiAmount. The operation will only succeed if the Proxy holds enough Dai for the swap; otherwise, the transaction will revert. Calling this function will carry out the following actions:
 
@@ -1676,9 +1707,11 @@ Only an operator with the relayer role can swap Dai to USDS. To do so, they must
 - The contract will approve the DaiUsds migrator to spend the specified Dai amount from the Proxy.
 - The contract will swap Dai to USDS at a 1:1 ratio by calling the `daiToUsds` function on the migrator, sending the resulting USDS to the proxy.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function swapDAIToUSDS(uint256 daiAmount) external`
+```solidity
+function swapDAIToUSDS(uint256 daiAmount) external
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.6 - PSM Functions [Core]  <!-- UUID: 4ee9a639-8b91-4bd9-8993-9efe3117524a -->
 
@@ -1688,7 +1721,7 @@ The documents herein define the swap operations performed by the Pattern Liquidi
 
 The documents herein define a series of operations for an operator to `swap` USDS to USDC through the PSM.
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.6.1.1 - Call swapUSDSToUSDC Function [Core]  <!-- UUID: b08f57de-599d-46e4-aabe-64b1db5a38ad -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.6.1.1 - swapUSDSToUSDC Function [Core]  <!-- UUID: b08f57de-599d-46e4-aabe-64b1db5a38ad -->
 
 Only an operator with the relayer role can swap USDS to USDC via the PSM. To do so, they must call the `swapUSDSToUSDC` function on the Controller contract on mainnet, providing the usdcAmount (denominated in 1e6 precision to match PSM USDC handling). The operation will only succeed if the ALM Proxy holds at least the equivalent amount of USDS for the swap; otherwise, the transaction will revert. The rate limit configuration serves as whitelisting for swaps. Calling this function will carry out the following actions:
 
@@ -1700,15 +1733,17 @@ Only an operator with the relayer role can swap USDS to USDC via the PSM. To do 
 - The contract will approve the PSM to spend the Dai.
 - The contract will swap Dai to USDC at a 1:1 ratio with no fee via psm.buyGemNoFee, sending USDC to the proxy.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function swapUSDSToUSDC(uint256 usdcAmount) external`
+```solidity
+function swapUSDSToUSDC(uint256 usdcAmount) external
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.6.2 - Swap USDC To USDS [Core]  <!-- UUID: 9d828ddb-7423-41cb-9adb-43d4cbfc9d38 -->
 
 The documents herein define a series of operations for an operator to `swap` USDC to USDS through the PSM.
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.6.2.1 - Call swapUSDCToUSDS Function [Core]  <!-- UUID: 355f4606-5346-41d5-8ea7-2c4490d761e1 -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.6.2.1 - swapUSDCToUSDS Function [Core]  <!-- UUID: 355f4606-5346-41d5-8ea7-2c4490d761e1 -->
 
 Only an operator with the relayer role can swap USDC to USDS via the PSM. To do so, they must call the `swapUSDCToUSDS` function on the Controller contract on mainnet, providing the usdcAmount (denominated in 1e6 precision to match PSM USDC handling). The operation will only succeed if the ALM Proxy holds at least the amount of USDC specified for the swap; otherwise, the transaction will revert. The rate limit configuration serves as whitelisting for swaps. Calling this function will carry out the following actions:
 
@@ -1722,15 +1757,17 @@ Only an operator with the relayer role can swap USDC to USDS via the PSM. To do 
 - The contract will approve the daiUsds contract to spend the Dai amount from the ALM Proxy.
 - The contract will swap Dai to USDS at a 1:1 ratio via daiUsds, sending USDS to the proxy.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function swapUSDCToUSDS(uint256 usdcAmount) external`
+```solidity
+function swapUSDCToUSDS(uint256 usdcAmount) external
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.6.3 - Transfer Token Via LayerZero [Core]  <!-- UUID: 901bf629-cee3-4296-afd6-d1e7779d15bb -->
 
 The documents herein define the steps for a relayer to `transfer` a token via LayerZero to a destination endpoint, with the assets sent according to the configured recipient.
 
-###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.6.3.1 - Call transferTokenLayerZero Function [Core]  <!-- UUID: 24c70856-ba73-4b1e-86db-1d7829220c49 -->
+###### A.6.1.1.6.2.6.1.2.2.1.2.1.2.6.3.1 - transferTokenLayerZero Function [Core]  <!-- UUID: 24c70856-ba73-4b1e-86db-1d7829220c49 -->
 
 Only an operator with the relayer role can transfer tokens via LayerZero. To do so, they must call the `transferTokenLayerZero` function on the Controller contract on mainnet, providing the oftAddress, amount, and destinationEndpointId (payable for native fees). The operation will only succeed if the ALM Proxy holds sufficient tokens and fees; otherwise, the transaction will revert. Calling this function will carry out the following actions:
 
@@ -1741,9 +1778,11 @@ Only an operator with the relayer role can transfer tokens via LayerZero. To do 
 - The contract will quote the OFT receipt to set the minimum amount received.
 - The contract will quote the messaging fee and execute the send via proxy.doCallWithValue, passing the fee value.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function transferTokenLayerZero(address oftAddress, uint256 amount, uint32  destinationEndpointId) external payable`
+```solidity
+function transferTokenLayerZero(address oftAddress, uint256 amount, uint32 destinationEndpointId) external payable
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.3 - Rate Limit Management [Core]  <!-- UUID: 2b03d21b-d03a-4c0e-8d90-d5a2f5dd9140 -->
 
@@ -1755,9 +1794,11 @@ Anyone can query the full rate limit data for a specific key. Calling this funct
 
 - The contract will return the stored RateLimitData struct from the _data mapping for the key.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function getRateLimitData(bytes32 key) external override view returns (RateLimitData memory)`
+```solidity
+function getRateLimitData(bytes32 key) external override view returns (RateLimitData memory)
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.3.2 - Set Rate Limit Data [Core]  <!-- UUID: 89b060bd-1026-46ec-ab32-d032edb58f83 -->
 
@@ -1768,11 +1809,15 @@ Only an operator with the admin role is able to set or update rate limit data fo
 - The contract will store the provided data in the _data mapping as a RateLimitData struct.
 - The contract will emit a RateLimitDataSet event with the key and provided values.
 
-The function calls are as follows:
+The function signatures are as follows:
 
-`function setRateLimitData(bytes32 key, uint256 maxAmount, uint256 slope, uint256 lastAmount, uint256 lastUpdated) public override onlyRole(DEFAULT_ADMIN_ROLE)
+```solidity
+function setRateLimitData(bytes32 key, uint256 maxAmount, uint256 slope, uint256 lastAmount, uint256 lastUpdated) public override onlyRole(DEFAULT_ADMIN_ROLE)
+```
 
-function setRateLimitData(bytes32 key, uint256 maxAmount, uint256 slope) external override`
+```solidity
+function setRateLimitData(bytes32 key, uint256 maxAmount, uint256 slope) external override
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.3.3 - Set Unlimited Rate Limit Data [Core]  <!-- UUID: 7c4bdc16-13e0-47b4-8988-18e9720eb292 -->
 
@@ -1780,9 +1825,11 @@ Only an operator with the admin role is able to set unlimited rate limit data fo
 
 - The contract will call setRateLimitData internally with type(uint256).max for maxAmount and lastAmount, 0 for slope, and the current block timestamp for lastUpdated.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function setUnlimitedRateLimitData(bytes32 key) external override`
+```solidity
+function setUnlimitedRateLimitData(bytes32 key) external override
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.3.4 - Get Current Rate Limit [Core]  <!-- UUID: b0afea3f-9ff2-4462-a771-522b1256a343 -->
 
@@ -1792,9 +1839,11 @@ Anyone can query the current rate limit value for a specific key, accounting for
 - If maxAmount is type(uint256).max (unlimited case), the contract will return type(uint256).max.
 - Otherwise, the contract will calculate and return the minimum of (slope * time elapsed since lastUpdated + lastAmount) and maxAmount.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function getCurrentRateLimit(bytes32 key) public override view returns (uint256)`
+```solidity
+function getCurrentRateLimit(bytes32 key) public override view returns (uint256)
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.3.5 - Trigger Rate Limit Decrease [Core]  <!-- UUID: 9f76a9bc-5451-4ff7-8dcd-153e4c47fe72 -->
 
@@ -1809,9 +1858,11 @@ Only an operator with the controller role can trigger a decrease in the rate lim
 - The contract will emit a RateLimitDecreaseTriggered event with the key, amountToDecrease, currentRateLimit, and newLimit.
 - The contract will return the newLimit.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function triggerRateLimitDecrease(bytes32 key, uint256 amountToDecrease) external override onlyRole(CONTROLLER) returns (uint256 newLimit)`
+```solidity
+function triggerRateLimitDecrease(bytes32 key, uint256 amountToDecrease) external override onlyRole(CONTROLLER) returns (uint256 newLimit)
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.1.4 - Instance Lifecycle Management [Core]  <!-- UUID: 568f470e-adce-49ee-8cbe-756757814dc5 -->
 
@@ -1837,9 +1888,11 @@ In the event of a compromised Relayer, the `FREEZER_ROLE` can call the function 
 - The contract will revoke the relayer role from the specified address.
 - The contract will emit a `RelayerRemoved(relayer)` event.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function removeRelayer(address relayer) external`
+```solidity
+function removeRelayer(address relayer) external
+```
 
 ###### A.6.1.1.6.2.6.1.2.2.3.2 - Redeem All Mainnet Positions [Core]  <!-- UUID: d1885385-a7d8-4d1c-b345-a843a5001052 -->
 
@@ -1851,7 +1904,9 @@ In order to withdraw all ERC-4626 balances, the operator must call the `redeemER
 
 The function call is as follows:
 
-`function redeemERC4626(address(token), token.balanceOf(address(proxy)))`
+```solidity
+redeemERC4626(address(token), token.balanceOf(address(proxy)))
+```
 
 For more detailed instructions on the code to execute this, see [A.6.1.1.6.2.6.1.2.2.1.2.1.2.3 - ERC-4626 Functions](c6dcf1ab-9861-4a41-9edc-ea79b705db2d).
 
@@ -1861,7 +1916,9 @@ This document defines the action that should be performed by an operator if ther
 
 The function call is as follows:
 
-`function swapUSDCToUSDS(usdc.balanceOf(address(proxy))`
+```solidity
+swapUSDCToUSDS(usdc.balanceOf(address(proxy)))
+```
 
 For more detailed instructions on the code to execute this see [A.6.1.1.6.2.6.1.2.2.1.2.1.2.6.2 - Swap USDC To USDS](9d828ddb-7423-41cb-9adb-43d4cbfc9d38).
 
@@ -1871,7 +1928,9 @@ This document defines the action that should be performed if there is a need to 
 
 The function call is as follows:
 
-`function burnUSDS(usds.balanceOf(address(proxy))`
+```solidity
+burnUSDS(usds.balanceOf(address(proxy)))
+```
 
 More detailed instructions on the code to execute this, see [A.6.1.1.6.2.6.1.2.2.1.2.1.2.1.2 - Burn USDS](886d04ba-23c3-45fb-ac5d-044288a621e1).
 
@@ -1976,7 +2035,7 @@ The documents herein contain operational procedures or monitoring requirements u
 
 The documents herein define the steps for a relayer to redeem vault shares from Maple.
 
-###### A.6.1.1.6.2.6.1.3.1.1.1.3.1.1 - Call RequestMapleRedemption Function [Core]  <!-- UUID: d080330d-912e-4c6d-9c81-714ce4b544a1 -->
+###### A.6.1.1.6.2.6.1.3.1.1.1.3.1.1 - requestMapleRedemption Function [Core]  <!-- UUID: d080330d-912e-4c6d-9c81-714ce4b544a1 -->
 
 Only an operator with the relayer role can request the redemption of shares from Maple. To do so, they must call the `requestMapleRedemption` function on the Controller contract on mainnet, providing the Maple token address and the number of shares to request. All Maple redemption operations are performed on behalf of the ALM Proxy and the destination address is always set to the proxy by the contract. Calling this function will carry out the following actions:
 
@@ -1984,11 +2043,13 @@ Only an operator with the relayer role can request the redemption of shares from
 - The contract will ensure the redemption amount is within the allowed rate limit for the specified vault and decrease the rate limit for the redemption amount.
 - The contract will submit a redemption request to the vault. Assets will not be received immediately; they must be claimed in a separate step after the vault processes the redemption.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function requestMapleRedemption(address mapleToken, uint256 shares) external`
+```solidity
+function requestMapleRedemption(address mapleToken, uint256 shares) external
+```
 
-###### A.6.1.1.6.2.6.1.3.1.1.1.3.1.2 - Call CancelMapleRedemption Function [Core]  <!-- UUID: 85d7a1f5-3361-49cf-b087-b027183cb640 -->
+###### A.6.1.1.6.2.6.1.3.1.1.1.3.1.2 - cancelMapleRedemption Function [Core]  <!-- UUID: 85d7a1f5-3361-49cf-b087-b027183cb640 -->
 
 Only an operator with the relayer role can cancel a previously requested redemption of shares from Maple. To do so, they must call the `cancelMapleRedemption` function on the Controller contract on mainnet, providing the Maple token address and the number of shares to cancel. All Maple cancellations of redemption operations are performed on behalf of the ALM Proxy. Calling this function will carry out the following actions:
 
@@ -1996,9 +2057,11 @@ Only an operator with the relayer role can cancel a previously requested redempt
 - The contract will check that a rate limit exists for the asset. If no rate limit exists the transaction will revert.
 - The contract will submit a cancellation request to the vault, removing the specified number of shares from the pending redemption.
 
-The function call is as follows:
+The function signature is as follows:
 
-`function cancelMapleRedemption(address mapleToken, uint256 shares) external`
+```solidity
+function cancelMapleRedemption(address mapleToken, uint256 shares) external
+```
 
 ##### A.6.1.1.6.2.6.1.4 - Completed Instances [Core]  <!-- UUID: f7a6d433-9be9-4140-89b4-eacf579522e4 -->
 

--- a/content/A.6.1.1.7 - Osero.md
+++ b/content/A.6.1.1.7 - Osero.md
@@ -1544,11 +1544,11 @@ The `maxSlippage` for this Instance is 0.01%.
 
 ###### A.6.1.1.7.2.6.1.3.1.1.1.2.5.2 - Maximum Exposure [Core]  <!-- UUID: 7baff09a-9aae-4abc-9643-dcb20940fe4d -->
 
-The Maximum Exposure for this Instance is 25,000,000 USDS.
+The Maximum Exposure for this Instance is 100,000,000 USDS.
 
 ###### A.6.1.1.7.2.6.1.3.1.1.1.2.5.3 - Capital Ratio Requirement [Core]  <!-- UUID: 771b1a44-5bb6-4c9b-92de-e45485c5a11f -->
 
-The Capital Ratio Requirement for this Instance, as specified in [A.3.2.1.1.1 - Capital Ratio Requirement](3828778e-0197-4ce9-a836-6770d04f2ea9), is 10%.
+The Capital Ratio Requirement for this Instance, as specified in [A.3.2.1.1.1 - Capital Ratio Requirement](3828778e-0197-4ce9-a836-6770d04f2ea9), is 5%.
 
 ###### A.6.1.1.7.2.6.1.3.1.1.1.3 - Instance-specific Operational Processes [Core]  <!-- UUID: ff10e260-7465-4dd0-a1c3-899a66f3bbcb -->
 


### PR DESCRIPTION
On behalf of Core GovOps, we are submitting the Atlas Edit Weekly Cycle proposal below.

This proposal includes the following edits:

- **Express Atlas Rates As Annual Percentage Rates With Monthly Compounding** - Changes the default convention for rates defined in the Atlas from annual percentage yields to annual percentage rates with monthly compounding. Updates the Base Rate, the Sky Savings Rate formula, and the Agent Credit Line Borrow Rate to match.
- **Add Core Council Risk Advisor Fallback For Independent Governance Risk Assessment** - Specifies that under the Independent Governance path, if a Prime Agent has no designated independent risk assessor, the Core Council Risk Advisor conducts the Prime Spell's financial risk assessment instead.
- **Add 1inch And Kyber Distribution Reward Instances To Skybase** - Adds Instances of the Distribution Reward Primitive for 1inch and Kyber.
- **Update Osero SparkLend USDS Instance Off-Chain Parameters** - Updates the off-chain parameters for Osero's SparkLend allocation: reduces the CRR from 10% to 5% and increases the maximum exposure from 25 million USDS to 100 million USDS.
- **Housekeeping Updates** - Corrects tense and dates in several Atlas documents now that the cycles and events they describe have concluded, standardizes contract terminology, and formats code excerpts in several Prime Agent Artifacts as fenced code blocks.
