### PR TITLE
Atlas Edit Proposal — 2026-09-14

### DIFF
--- a/content/A.1 - The-Governance-Scope.md
+++ b/content/A.1 - The-Governance-Scope.md
@@ -2832,6 +2832,8 @@ Prior to publication of Forum posts as specified in [A.1.10.2.3.2.2.3.2.2 - Prim
 
 Each proposed Prime Spell action must be included in a Forum post on the Sky Forum. Each Forum post must contain the Technical Scope, as specified in [A.1.10.2.5.2.1 - Technical Scope Template](b9ba6658-87a9-4421-9d20-386df8cea450), the Financial Risk Assessment, and, if relevant, a Technical Risk Assessment.
 
+Each Forum post must be published under the Prime Agent's own category on the Sky Forum. The title of the Forum post must consist of the target Spell date in square brackets, followed by "Proposed Changes to", the Prime Agent's name, and "for Upcoming Spell".
+
 Under the Sky Governance path, the Forum posts must be published by Wednesday, 16:00 UTC of week 1.
 
 Under the Independent Governance path, the Forum posts must be published by end of Friday of week 1.
@@ -4439,7 +4441,7 @@ The Deployment Checklist is maintained by Core GovOps. All changes must be submi
 
 ###### A.1.10.2.5.2.3 - Morpho Deployment Verification Guide [Core]  <!-- UUID: 45adb133-13b4-402c-8c2b-2473d78ff72e -->
 
-The Morpho Deployment Verification Guide defines the steps for verifying vault and market deployments made through the Morpho protocol's smart contract factories, covering factory deployment provenance, market and oracle parameters, vault roles, and timelock settings. It is maintained as specified in [A.1.10.2.5.2.3.1 - Morpho Deployment Verification Guide Update Process](5df5c86a-7efa-4c04-afda-dd9f3a21e596).
+The Morpho Deployment Verification Guide defines the steps for verifying vault and market deployments made through the Morpho protocol's smart contract factories, covering factory deployment provenance, market and oracle parameters, vault roles, and timelock settings. The guide is maintained as specified in [A.1.10.2.5.2.3.1 - Morpho Deployment Verification Guide Update Process](5df5c86a-7efa-4c04-afda-dd9f3a21e596). Morpho vaults used by Prime Agents must also comply with [A.2.2.10.1.1.1.3 - Morpho Vault Curation Framework](915a36c0-754c-41f9-ada1-2fec0816f7b8).
 
 ###### A.1.10.2.5.2.3.1 - Morpho Deployment Verification Guide Update Process [Core]  <!-- UUID: 5df5c86a-7efa-4c04-afda-dd9f3a21e596 -->
 

--- a/content/A.2 - The-Support-Scope.md
+++ b/content/A.2 - The-Support-Scope.md
@@ -4007,6 +4007,123 @@ The following code increases the `RateLimit` for a specific key, restricted to t
         emit RateLimitIncreaseTriggered(key, amountToIncrease, currentRateLimit, newLimit);
     }`
 
+###### A.2.2.10.1.1.1.3 - Morpho Vault Curation Framework [Core]  <!-- UUID: 915a36c0-754c-41f9-ada1-2fec0816f7b8 -->
+
+The documents herein define the requirements for Morpho vaults used by Prime Agents to deploy capital through the Allocation System Primitive.
+
+###### A.2.2.10.1.1.1.3.1 - Role Configuration [Core]  <!-- UUID: 686b81a9-450d-4340-a25a-5a069cbe8788 -->
+
+Morpho vaults must use the following role configuration:
+
+- The Owner role must be held by the relevant Prime Agent's SubProxy.
+- The Curator role must be held by a Multisig jointly controlled by the Operational Executor Agent and either the relevant Prime Agent or an external curator. The Multisig must require a 2 of 2 signer approval threshold.
+- The Allocator role may be held by an externally owned account or Multisig controlled by the relevant Prime Agent or an external curator, or by the Morpho Public Allocator contract. Where the Morpho Public Allocator contract holds the Allocator role, any emergency action that withdraws vault assets from a market must also set the Public Allocator's caps for that market to zero, so that the Public Allocator cannot reallocate assets back into that market.
+- The Sentinel role must be held by at least one (1) address controlled by the Operational Executor Agent, using a signer set separate from the signer set controlling the Curator role. Additional Sentinel addresses may be designated. These additional Sentinel addresses are recommended but not required, and no restriction applies to who may control them. Any automated monitoring solution serving as a Sentinel must be capable of automatically revoking pending actions when it detects a threat.
+
+###### A.2.2.10.1.1.1.3.2 - Market Eligibility Requirements [Core]  <!-- UUID: 022092c0-7a70-4b74-94c6-ed1b58f42cd1 -->
+
+The documents herein define the requirements for markets used by Morpho vaults.
+
+###### A.2.2.10.1.1.1.3.2.1 - Eligible Loan Assets [Core]  <!-- UUID: 881e768f-3438-4163-8965-a4bbd1752b94 -->
+
+USDC, USDT, and pyUSD, as defined in [A.3.3.2.1.3 - Cash Stablecoins](066a4d9f-13ed-4ac3-a55a-df7bf3429649), are eligible loan assets. RLUSD and USDG are also eligible loan assets.
+
+Any other loan asset must undergo a risk review before it may be used.
+
+###### A.2.2.10.1.1.1.3.2.2 - Eligible Collateral And Liquidation Loan-To-Value Limits [Core]  <!-- UUID: fe70a940-5ada-48c5-8826-b361ef33275f -->
+
+The eligible collateral assets and maximum liquidation loan-to-value limits are:
+
+| Collateral Asset | Maximum Liquidation Loan-To-Value |
+| --- | --- |
+| ETH | 86% |
+| cbBTC | 86% |
+| stETH | 86% |
+| WBTC | 86% |
+| sUSDS | 96.5% |
+
+Lower liquidation loan-to-value tiers are permitted and may result in a lower Instance Financial CRR. The Instance Financial CRR for cbBTC, WBTC, and stETH markets using an 86% liquidation loan-to-value limit must account for any difference between that limit and the limit produced by the applicable risk model. Any collateral asset not listed herein requires due diligence and approval by the [A.0.1.1.46 - Core Council](5a03a0c4-a47a-409c-9b23-52ac93e63d45) before adoption.
+
+###### A.2.2.10.1.1.1.3.2.3 - Oracle Requirements [Core]  <!-- UUID: be4f3bc0-70e4-478c-8c86-e889846198e3 -->
+
+The documents herein define oracle requirements for markets used by Morpho vaults.
+
+###### A.2.2.10.1.1.1.3.2.3.1 - Multi-Source Oracle Methodology [Core]  <!-- UUID: 191fbabc-d4e1-4ec4-9ea8-35b80eb809b0 -->
+
+Oracle-based market pricing must use Chainlink, RedStone, and Chronicle as its sources. When all three (3) sources are available and valid, the median of those sources must be used. If only two (2) valid sources are available, the average of those sources must be used. If only one (1) valid source is available, a credible fallback source must be used.
+
+###### A.2.2.10.1.1.1.3.2.3.2 - Eligible Collateral Oracle Methodologies [Core]  <!-- UUID: fe7c0ccf-c570-471a-815a-6b4b9cda5e29 -->
+
+The following pricing methods apply to eligible collateral assets and must comply with the [A.2.2.10.1.1.1.3.2.3.1 - Multi-Source Oracle Methodology](191fbabc-d4e1-4ec4-9ea8-35b80eb809b0) for any market-pricing component:
+
+- ETH: oracle market pricing.
+- cbBTC: BTC oracle market pricing.
+- stETH: the wstETH-to-ETH contract exchange rate multiplied by the ETH oracle market price.
+- WBTC: oracle market pricing.
+- sUSDS: the sUSDS-to-USDS contract exchange rate multiplied by the USDS oracle market price.
+
+###### A.2.2.10.1.1.1.3.2.3.3 - Temporary Single-Source Oracle Exception [Core]  <!-- UUID: 079d2e2c-fa22-4f3c-a929-82d45af38097 -->
+
+A single-source Chainlink oracle may be used temporarily for a major collateral asset. Such a configuration should migrate toward the [A.2.2.10.1.1.1.3.2.3.1 - Multi-Source Oracle Methodology](191fbabc-d4e1-4ec4-9ea8-35b80eb809b0), following the structure used by SparkLend and on a schedule coordinated with the affected Prime Agent to avoid unnecessary operational disruption.
+
+###### A.2.2.10.1.1.1.3.2.3.4 - New Collateral Oracle Approval [Core]  <!-- UUID: c7723797-b2c8-4334-a185-592797456f87 -->
+
+The oracle methodology for any new collateral asset requires due diligence and approval by the [A.0.1.1.46 - Core Council](5a03a0c4-a47a-409c-9b23-52ac93e63d45) before adoption.
+
+###### A.2.2.10.1.1.1.3.2.4 - Interest Rate Requirements [Core]  <!-- UUID: 4d30ef6e-bed6-4abd-b6dd-7c748e9d7ef1 -->
+
+Morpho Blue variable-rate markets must use the Morpho Adaptive Curve Interest Rate Model (https://docs.morpho.org/developers/contracts/irm/#adaptivecurveirm). Morpho Midnight fixed-rate markets use market-set rates rather than an interest rate model. A maker posts an offer at a price in a fixed-maturity market, and the implied fixed rate for the remaining term is locked when a taker executes the offer.
+
+###### A.2.2.10.1.1.1.3.3 - Timelock Requirements [Core]  <!-- UUID: 1078548f-1086-49d2-bc01-f5727f088e41 -->
+
+The documents herein define the minimum timelock requirements for protected functions used by Morpho vaults and their adapters.
+
+###### A.2.2.10.1.1.1.3.3.1 - Vault Timelock Requirements [Core]  <!-- UUID: 14aba6cb-eb34-4780-84c1-908666835569 -->
+
+Morpho vaults must use at least the following timelock delays for protected functions:
+
+| Action | Minimum Timelock Delay |
+| --- | --- |
+| Abdicate | seven (7) days |
+| Add adapter | seven (7) days |
+| Increase absolute cap | seven (7) days |
+| Increase relative cap | seven (7) days |
+| Increase timelock duration | seven (7) days |
+| Remove adapter | seven (7) days |
+| Set adapter registry | seven (7) days |
+| Set force deallocate penalty | seven (7) days |
+| Set management fee | three (3) days |
+| Set management fee recipient | three (3) days |
+| Set performance fee | three (3) days |
+| Set performance fee recipient | three (3) days |
+| Set receive assets gate | seven (7) days |
+| Set receive shares gate | seven (7) days |
+| Set send assets gate | seven (7) days |
+| Set send shares gate | seven (7) days |
+
+Adding or removing an allocator must not be subject to a timelock delay, so that a compromised allocator can be removed immediately. Decreases to absolute or relative caps may be executed without delay. A decrease to a function's timelock duration is subject to that function's then-current timelock delay. For the Set adapter registry, Set receive assets gate, Set receive shares gate, and Set send shares gate functions, permanently abdicating the function is accepted in place of the timelock delay.
+
+###### A.2.2.10.1.1.1.3.3.2 - Adapter Timelock Requirements [Core]  <!-- UUID: 91ba9acf-6ed7-4214-8b6b-adfb03427ae1 -->
+
+Adapters used by Morpho vaults must use at least the following timelock delays for protected adapter functions:
+
+| Action | Minimum Timelock Delay |
+| --- | --- |
+| Abdicate | seven (7) days |
+| Burn shares | three (3) days |
+| Increase timelock | seven (7) days |
+| Skim recipient | three (3) days |
+
+###### A.2.2.10.1.1.1.3.4 - Eligible Chains [Core]  <!-- UUID: 8e63ce99-4c7a-497f-a20a-92cba946b77d -->
+
+Morpho vaults may initially be deployed on Ethereum Mainnet, Base, and Robinhood Chain. Deployment on any other chain requires a risk review.
+
+###### A.2.2.10.1.1.1.3.5 - Transition And Compliance [Core]  <!-- UUID: 41824fb1-a4e0-4f58-9095-0b3e646fb42c -->
+
+Notwithstanding the other requirements of the Morpho Vault Curation Framework, Morpho vault exposure existing as of August 17, 2026, must be migrated to new vaults or upgraded to comply with the framework no later than the execution of the October 8, 2026 Executive Vote. Migration may be staged to account for underlying market utilization and existing vault configurations, but must be completed by that time.
+
+Following the execution of the October 8, 2026 Executive Vote, noncompliant Morpho vault allocations are subject to the Instance Financial CRR specified in [A.3.2.2.1.1.1.1.3.8.2 - Noncompliant Morpho Vault Allocations](20aa9663-214b-46f5-8b37-53be387b996b).
+
 ###### A.2.2.10.1.1.1.6 - Security Specifications [Core]  <!-- UUID: 905a0c30-5758-48e8-9006-b52ced11fa42 -->
 
 The documents herein specify required security measures for the setup and ongoing management of the Allocation System Primitive.
@@ -4452,7 +4569,7 @@ The documents herein define how the total reward pool is distributed to individu
 
 ###### A.2.2.11.1.4.1 - Integration With Treasury Management Function [Core]  <!-- UUID: dc825d62-60cf-4701-ac8f-b48257b4f9a6 -->
 
-Distributions of Core Governance Rewards are made on a monthly basis as part of the Treasury Management Function.
+Distributions of Core Governance Rewards are made on a monthly basis as part of the Treasury Management Function. Following the Final Calculation for each Monthly Settlement Cycle, as specified in [A.2.4.1.2.1.2 - Final Calculation By Core GovOps](9de89bf3-9051-44f1-9ec0-d362ee4d4b38), each Prime Agent's share of the reward pool for the month covered by that cycle, allocated as specified in [A.2.2.11.1.4.2 - Allocation Based On Staked SKY](f8d35814-d8bb-423f-97ce-35629bcc7a5e), is paid from the Core Council Buffer (see [A.2.3.1.2.2.2.1 - Core Council Buffer](8b6781d7-f35c-4ffe-b8ed-299fa98e3da7)). Core Governance Rewards are funded out of the Core Council Allocation (see [A.2.3.1.2.2.2 - Core Council Allocation](91b281c2-0687-45a3-939d-0480c7c33f9f)). They are not included in the net amounts due to or from Prime Agents under the Monthly Settlement Cycle, are not recognized as Expenses for purposes of [A.2.3.1.2.1 - Step 0: Net Revenue](c09435ff-d876-442a-899c-ad494175500b), and do not reduce Net Revenue.
 
 ###### A.2.2.11.1.4.2 - Allocation Based On Staked SKY [Core]  <!-- UUID: f8d35814-d8bb-423f-97ce-35629bcc7a5e -->
 
@@ -4668,11 +4785,13 @@ Step 3 Capital is allocated as follows:
 - Forty-five percent (45%) of Step 3 Capital is distributed to SKY stakers as USDS Staking Rewards as specified in [A.2.3.1.2.5 - Step 4: Staking Rewards](bb163691-630e-4fda-88f1-96381a649fa0).
 - Ten percent (10%) of Step 3 Capital is used by the Smart Burn Engine to buy back SKY, and the SKY tokens acquired through these buybacks are burned.
 
+The allocation between SKY Staking Rewards and USDS Staking Rewards is adjusted as specified in [A.2.3.1.4.1 - Staking Rewards Rate Adjustment](de233df4-34cc-4e88-a065-9a9dde9add3c).
+
 The specific parameters governing the execution of Smart Burn Engine buybacks are specified in [A.3.5.2 - Smart Burn Engine Parameters](ddb90fee-2851-4bf0-b924-f1d73e30ce7a).
 
 ##### A.2.3.1.2.5 - Step 4: Staking Rewards [Core]  <!-- UUID: bb163691-630e-4fda-88f1-96381a649fa0 -->
 
-Step 4 Capital is distributed to SKY stakers as Staking Rewards. Step 4 Capital comprises (1) USDS allocated from Step 3, distributed as USDS Staking Rewards, and (2) SKY tokens acquired by the Smart Burn Engine through buybacks specified in [A.2.3.1.2.4 - Step 3: Smart Burn Engine](5ce73730-4d5d-479c-b01e-40e87f072121), distributed as SKY Staking Rewards.
+Step 4 Capital is distributed to SKY stakers as Staking Rewards. Step 4 Capital comprises (1) USDS allocated from Step 3, distributed as USDS Staking Rewards, and (2) SKY tokens acquired by the Smart Burn Engine through buybacks attributable to the SKY Staking Rewards share specified in [A.2.3.1.2.4 - Step 3: Smart Burn Engine](5ce73730-4d5d-479c-b01e-40e87f072121), distributed as SKY Staking Rewards.
 
 #### A.2.3.1.3 - Sourcing Of Internal Senior Risk Capital [Core]  <!-- UUID: ac7a6636-acbc-40c9-abc1-4543c0beb300 -->
 
@@ -4682,15 +4801,17 @@ Internal Senior Risk Capital (ISRC) consists of a portion of the excess capital 
 
 The Sky Treasury Management Function is implemented through Executive Votes that update the corresponding on-chain parameters. Changes to the documents herein define the intended operation of the Sky Treasury Management Function; operational effect on the Sky Protocol requires a subsequent Executive Vote. Until such an Executive Vote is executed, prior on-chain parameters remain in force.
 
-Pending activation of the USDS Staking Rewards specified in [A.2.3.1.2.4 - Step 3: Smart Burn Engine](5ce73730-4d5d-479c-b01e-40e87f072121), the Smart Burn Engine continues to operate under existing on-chain parameters specified in [A.3.5.2 - Smart Burn Engine Parameters](ddb90fee-2851-4bf0-b924-f1d73e30ce7a), and SKY staking rewards continue to be funded from the Protocol Treasury via the Vesting Stream Contract specified in [A.4.4.1.4.2.1.3 - Vesting Stream Contract](21a8978d-10a5-4151-b99a-ca8115fe0a6d). The USDS Staking Rewards become operational when the SKY tokens funding the Vesting Stream Contract approach depletion. The Core Facilitator, in consultation with the Core Council Risk Advisor, determines when this activation occurs and effects the corresponding on-chain parameter changes through an Executive Vote.
+The allocation of Step 3 Capital specified in [A.2.3.1.2.4 - Step 3: Smart Burn Engine](5ce73730-4d5d-479c-b01e-40e87f072121) is implemented through the Splitter Module operating under the parameters specified in [A.3.5.2 - Smart Burn Engine Parameters](ddb90fee-2851-4bf0-b924-f1d73e30ce7a). The share of each transfer allocated to USDS Staking Rewards funds the USDS rewards contract directly. The remainder is used by the Smart Burn Engine to buy back SKY. SKY tokens attributable to the SKY Staking Rewards share are distributed to SKY stakers via the Vesting Stream Contract specified in [A.4.4.1.2.2.3 - Vesting Stream Contract](21a8978d-10a5-4151-b99a-ca8115fe0a6d). SKY tokens attributable to the burn share are burned through Executive Votes as part of the implementation of the Sky Treasury Management Function.
 
-##### A.2.3.1.4.1 - Short Term SKY Staking Rewards Rate [Core]  <!-- UUID: de233df4-34cc-4e88-a065-9a9dde9add3c -->
+##### A.2.3.1.4.1 - Staking Rewards Rate Adjustment [Core]  <!-- UUID: de233df4-34cc-4e88-a065-9a9dde9add3c -->
 
-Pending activation of the USDS Staking Rewards specified in [A.2.3.1.2.4 - Step 3: Smart Burn Engine](5ce73730-4d5d-479c-b01e-40e87f072121), no Step 4 Capital is allocated to SKY Staking Rewards. Instead, SKY Staking Rewards are funded from SKY token reserves held by the Protocol Treasury via the Vesting Stream Contract specified in [A.4.4.1.4.2.1.3 - Vesting Stream Contract](21a8978d-10a5-4151-b99a-ca8115fe0a6d), distributed at a rate equivalent to fifty percent (50%) of Step 2 Capital from the prior Monthly Settlement Cycle. The rate is determined by the Core Facilitator in consultation with the Core Council Risk Advisor following each Monthly Settlement Cycle, using the prior Monthly Settlement Cycle's Step 2 Capital and the price of SKY, and is implemented through an Executive Vote.
+The Core Facilitator, in consultation with the Core Council Risk Advisor, keeps the reward rate provided by SKY Staking Rewards and the reward rate provided by USDS Staking Rewards equivalent. The reward rate provided by each option is the annualized value of the rewards distributed to wallets electing that option relative to the value of the SKY those wallets have staked.
+
+To maintain equivalence, the Core Facilitator adjusts the allocation of Step 3 Capital between SKY Staking Rewards and USDS Staking Rewards from the allocation specified in [A.2.3.1.2.4 - Step 3: Smart Burn Engine](5ce73730-4d5d-479c-b01e-40e87f072121), and adjusts the rate of the vesting stream specified in [A.4.4.1.2.2.3 - Vesting Stream Contract](21a8978d-10a5-4151-b99a-ca8115fe0a6d). Smart Burn Engine parameters are modified as specified in [A.3.5.2.3 - Modification](499570de-9fae-4009-be34-c3330266030a), either through an Executive Vote or directly through the Smart Burn Engine Bounded External Access Module; vesting stream parameters are modified through an Executive Vote. The SKY Accumulation Percentage may not be set below the share of Step 3 Capital allocated to buyback and burn.
 
 #### A.2.3.1.5 - Allocation Modification [Core]  <!-- UUID: c4ef7fd6-c70c-4fe9-9665-97ad17443390 -->
 
-In the short term, the Core Council may reduce the allocations of Step 1 Capital (see [A.2.3.1.2.2 - Step 1: Security And Maintenance](324e9d22-70fe-4e44-82ab-118815f5c42e)) and Step 2 Capital (see [A.2.3.1.2.3 - Step 2: Aggregate Backstop Capital](2b28d464-e683-48ba-9a66-2fee05ea0a88)) below their specified levels and restore them up to those levels, and modify the allocation of Step 3 Capital among its three specified uses (see [A.2.3.1.2.4 - Step 3: Smart Burn Engine](5ce73730-4d5d-479c-b01e-40e87f072121)). A reduction to the Step 1 allocation may be apportioned among its components as the Core Council determines. For Step 2 Capital, the specified level is the retention its allocation formula specifies for the current state. The Core Council exercises this authority through a public post by the Core Facilitator on the Sky Forum, confirmed by Core GovOps and the Core Council Risk Advisor.
+In the short term, the Core Council may reduce the allocations of Step 1 Capital (see [A.2.3.1.2.2 - Step 1: Security And Maintenance](324e9d22-70fe-4e44-82ab-118815f5c42e)) and Step 2 Capital (see [A.2.3.1.2.3 - Step 2: Aggregate Backstop Capital](2b28d464-e683-48ba-9a66-2fee05ea0a88)) below their specified levels and restore them up to those levels, and modify the allocation of Step 3 Capital among its specified uses (see [A.2.3.1.2.4 - Step 3: Smart Burn Engine](5ce73730-4d5d-479c-b01e-40e87f072121)). A reduction to the Step 1 allocation may be apportioned among its components as the Core Council determines. For Step 2 Capital, the specified level is the retention its allocation formula specifies for the current state. The Core Council exercises this authority through a public post by the Core Facilitator on the Sky Forum, confirmed by Core GovOps and the Core Council Risk Advisor.
 
 The implementation of such modifications is authorized to proceed directly to an Executive Vote without requiring a prior Governance Poll.
 
@@ -4710,7 +4831,7 @@ The Monthly Settlement Cycle (MSC) synchronizes several key operational processe
 2. The monthly Senior Risk Capital (SRC) origination process is settled: the clearing price is established, costs are deducted from winning Prime Agents’ accounts, and their accounts are credited with Originated SRC (OSRC) for the upcoming month. See [A.3.2.2.4.3.5 - Settlement Of Origination](fff0112a-58dd-4041-97f9-7baf113b4e70).
 3. Queued conversions between USDS and srUSDS within the SRC system are processed. See [A.3.2.2.4.2.2 - Deposit And Redemption Queues](38a99586-4a13-4ce3-8b2f-cee025e0c390).
 4. Pioneer Incentive Pools are funded with an amount equivalent to the Sky Savings Rate multiplied by the balance of Unrewarded USDS. See [A.2.2.9.3 - Pioneer Chain Primitive](4c7be4c6-44b5-407a-94ae-3d7ca7e8039c).
-5. Smart Burn Engine parameters are updated at each Monthly Settlement Cycle based on the prior month's state. See [A.2.3.1.2.4 - Step 3: Smart Burn Engine](5ce73730-4d5d-479c-b01e-40e87f072121) and [A.3.5.2 - Smart Burn Engine Parameters](ddb90fee-2851-4bf0-b924-f1d73e30ce7a).
+5. Smart Burn Engine parameters are updated at each Monthly Settlement Cycle based on the prior month's state, and between Monthly Settlement Cycles as necessary as specified in [A.2.3.1.4.1 - Staking Rewards Rate Adjustment](de233df4-34cc-4e88-a065-9a9dde9add3c). See [A.2.3.1.2.4 - Step 3: Smart Burn Engine](5ce73730-4d5d-479c-b01e-40e87f072121) and [A.3.5.2 - Smart Burn Engine Parameters](ddb90fee-2851-4bf0-b924-f1d73e30ce7a).
 6. Critical Core GovOps functions related to the operationalization of Sky Primitives are executed, including payment/reimbursement processing, compliance monitoring, and the calculation and application of retroactive penalties.
 
 #### A.2.4.1.2 - Implementation [Core]  <!-- UUID: 75473c4b-69ba-4e6b-bbf6-2c926732364c -->
@@ -5589,6 +5710,12 @@ The founding team of Spark has proposed a cash grant of 1,100,000 USDS per month
 
 Sky Governance hereby consents to these grants and authorizes the execution of the associated funding payloads as specified in the referenced proposal.
 
+###### A.2.8.2.2.2.4.5.1.5 - Spark Foundation Grant Authorization: October 2026 [Core]  <!-- UUID: 1deecbd9-c3d8-45c4-a407-28386735833d -->
+
+The founding team of Spark has proposed a cash grant of 865,000 USDS to the Spark Foundation from Spark's Prime Treasury to cover October 2026 Spark Foundation expenses. Additionally, the founding team of Spark has proposed a grant of 45,000 USDS to the Spark Asset Foundation from Spark's Prime Treasury to cover October 2026 Spark Asset Foundation expenses.
+
+Sky Governance hereby consents to these grants and authorizes the execution of the associated funding payloads.
+
 ###### A.2.8.2.2.2.4.5.2 - Grove Foundation Grant Authorizations [Core]  <!-- UUID: db86fa15-45c6-4a44-9c2a-652fd3d227b0 -->
 
 The documents herein record Sky Governance authorizations for grants to the Grove Foundation.
@@ -5608,6 +5735,12 @@ Sky Governance hereby consents to this grant and authorizes the execution of the
 ###### A.2.8.2.2.2.4.5.2.3 - Grove Foundation Grant Authorization: August 2026 [Core]  <!-- UUID: a8075d68-a5ba-4b4d-bce5-0ad58130f9e5 -->
 
 The founding team of Grove has proposed a cash grant of 800,000 USDS to the Grove Foundation from Grove's Prime Treasury for August 2026. The purpose of this grant is to enable the Grove Foundation to fulfill its purpose of promoting the growth and development of Grove. This funding will support essential activities such as engineering and product development, community engagement and growth initiatives, research and governance contributions, infrastructure and operational maintenance, and administrative operations.
+
+Sky Governance hereby consents to this grant and authorizes the execution of the associated funding payload. The transfer must be made to the Grove Foundation Multisig at `0xE3EC4CC359E68c9dCE15Bf667b1aD37Df54a5a42` in a Grove Spell included in a Sky Executive Vote unless otherwise agreed by Sky and Grove.
+
+###### A.2.8.2.2.2.4.5.2.4 - Grove Foundation Grant Authorization: September 2026 [Core]  <!-- UUID: bd2d15af-e32a-4ce9-a7ac-5a5ff1665fd4 -->
+
+The founding team of Grove has proposed a cash grant of 800,000 USDS to the Grove Foundation from Grove's Prime Treasury for September 2026. The purpose of this grant is to enable the Grove Foundation to fulfill its purpose of promoting the growth and development of Grove. This funding will support essential activities such as engineering and product development, community engagement and growth initiatives, research and governance contributions, infrastructure and operational maintenance, and administrative operations.
 
 Sky Governance hereby consents to this grant and authorizes the execution of the associated funding payload. The transfer must be made to the Grove Foundation Multisig at `0xE3EC4CC359E68c9dCE15Bf667b1aD37Df54a5a42` in a Grove Spell included in a Sky Executive Vote unless otherwise agreed by Sky and Grove.
 

--- a/content/A.3 - The-Stability-Scope.md
+++ b/content/A.3 - The-Stability-Scope.md
@@ -770,6 +770,10 @@ The CRRs for the following market allocations in the vault are:
 - mF-One / USDC – LLTV: 91.5%
     - CRR = 100%
 
+###### A.3.2.2.1.1.1.1.3.8.2 - Noncompliant Morpho Vault Allocations [Core]  <!-- UUID: 20aa9663-214b-46f5-8b37-53be387b996b -->
+
+Following the execution of the October 8, 2026 Executive Vote, the Instance Financial CRR for any allocation to a Morpho vault that does not comply with [A.2.2.10.1.1.1.3 - Morpho Vault Curation Framework](915a36c0-754c-41f9-ada1-2fec0816f7b8) is 100%.
+
 ###### A.3.2.2.1.1.1.1.3.9 - Uniswap V3 [Core]  <!-- UUID: 200cd606-26e9-427e-b965-976e7140a976 -->
 
 Allocation to the AUSD / USDC Uniswap v3 pool via FalconX on Monad has a CRR of 3%. Total combined FalconX allocations must not exceed 100,000,000 USDS.
@@ -2904,11 +2908,9 @@ The current Smart Burn Engine parameters are:
 
 - kicker.khump: -200 million USDS (Threshold of Surplus Buffer for Splitter to activate)
 - kicker.kbump: 6,000 USDS
-- splitter.hop: 3,748 seconds
-- 55% of Splitter allocation is set to accumulate SKY
-- 45% of Splitter allocation is set to reward SKY stakers
-- burn (the percentage of the kicker.kbump to be moved to the underlying flapper): 55% (WAD * 1)
-- LSEV2-SKY-A USDS rewardsDuration: 3,748 seconds
+- splitter.hop: 2,504 seconds
+- burn (the percentage of the kicker.kbump to be moved to the underlying flapper): set as specified in [A.2.3.1.4.1 - Staking Rewards Rate Adjustment](de233df4-34cc-4e88-a065-9a9dde9add3c); the current value can be read by calling `burn()` on the Splitter contract
+- LSEV2-SKY-A USDS rewardsDuration: 2,504 seconds
 
 The rewardsDuration for the LSEV2-SKY-A USDS rewards contract must be set such that it is equal to the splitter.hop parameter.
 
@@ -2962,11 +2964,11 @@ The current value of the kbump parameter is specified in [A.3.5.2 - Smart Burn E
 
 ##### A.3.5.2.2.2 - Deployment [Core]  <!-- UUID: 0803e6b5-5755-431c-9ef0-999115f6f897 -->
 
-The activation of the Kicker Module will be executed in the October 30, 2025 Executive Vote. This action is authorized to proceed directly to an Executive Vote without a prior Governance Poll.
+The Kicker Module was activated in the October 30, 2025 Executive Vote. This action was authorized to proceed directly to an Executive Vote without a prior Governance Poll.
 
 #### A.3.5.2.3 - Modification [Core]  <!-- UUID: 499570de-9fae-4009-be34-c3330266030a -->
 
-The Core Facilitator, in consultation with the Core Council Risk Advisor, can modify the `kbump` and `hop` parameters of the Smart Burn Engine. Such a modification can be enacted either by proposing it for inclusion in an Executive Vote pursuant to the Operational Weekly Cycle, without requiring a prior Governance Poll, or by executing it directly through the SBE-BEAM within its bounds, as specified in [A.3.5.2.4 - Smart Burn Engine Bounded External Access Module](b57ac61b-f6b1-4025-bd44-569d0f2afe2f). LSEV2-SKY-A-USDS rewardsDuration should always match the value of the `hop` parameter without requiring prior governance authorization.
+The Core Facilitator, in consultation with the Core Council Risk Advisor, can modify the `kbump`, `hop`, and `burn` parameters of the Smart Burn Engine. Such a modification can be enacted either by proposing it for inclusion in an Executive Vote pursuant to the Operational Weekly Cycle, without requiring a prior Governance Poll, or by executing it directly through the SBE-BEAM within its bounds, as specified in [A.3.5.2.4 - Smart Burn Engine Bounded External Access Module](b57ac61b-f6b1-4025-bd44-569d0f2afe2f). LSEV2-SKY-A-USDS rewardsDuration should always match the value of the `hop` parameter without requiring prior governance authorization.
 
 The Core Facilitator must modify all parameters of the Smart Burn Engine as necessary to implement the allocation specified in [A.2.3.1.2.4 - Step 3: Smart Burn Engine](5ce73730-4d5d-479c-b01e-40e87f072121). Such a modification can be enacted either by proposing it for inclusion in an Executive Vote pursuant to the Operational Weekly Cycle, without requiring a prior Governance Poll, or by executing it directly through the SBE-BEAM within its bounds.
 

--- a/content/A.4 - The-Protocol-Scope.md
+++ b/content/A.4 - The-Protocol-Scope.md
@@ -32,13 +32,17 @@ Historically, MKR was the governance token of the Sky Protocol. As part of the t
 
 **MKR holders have voted to approve the deprecation of MKR as the governance token of the Sky Protocol with full knowledge of the changes being proposed. See **[**https://vote.makerdao.com/polling/QmcZNZg3**](https://vote.makerdao.com/polling/QmcZNZg3)**. This deprecation includes all actions defined in **[**A.4.1.2.1 - MKR To SKY Upgrade**](6bb8b5b2-a2a8-4728-bddb-28bf054de9b6)**, including, but not limited to, the removal of voting rights from MKR and the Delayed Upgrade Penalty**.
 
-###### A.4.1.2.1.1.1 - MKR To SKY Conversion Contract [Core]  <!-- UUID: 0a26f6d0-1b50-4015-b094-499724796f9e -->
+##### A.4.1.2.1.2 - MKR To SKY Conversion Contract [Core]  <!-- UUID: 0a26f6d0-1b50-4015-b094-499724796f9e -->
 
-The MKR to SKY conversion contract MKR_SKY allows users to upgrade from MKR to SKY at a conversion rate of 1 MKR to 24,000 SKY, subject to the Delayed Upgrade Penalty specified in [A.4.1.2.1.1.1.1 - MKR To SKY Upgrade Penalty](ec820ddb-5d12-43d8-81b7-a7602a70332a).
+The MKR to SKY conversion contract MKR_SKY allows users to upgrade from MKR to SKY at a conversion rate of 1 MKR to 24,000 SKY, subject to the Delayed Upgrade Penalty specified in [A.4.1.2.1.3 - MKR To SKY Upgrade Penalty](ec820ddb-5d12-43d8-81b7-a7602a70332a).
 
-###### A.4.1.2.1.1.1.1 - MKR To SKY Upgrade Penalty [Core]  <!-- UUID: ec820ddb-5d12-43d8-81b7-a7602a70332a -->
+##### A.4.1.2.1.3 - MKR To SKY Upgrade Penalty [Core]  <!-- UUID: ec820ddb-5d12-43d8-81b7-a7602a70332a -->
 
-In the September 18, 2025 Executive Vote, the Delayed Upgrade Penalty for the MKR to SKY conversion contract was set to 1%. The Delayed Upgrade Penalty will be increased gradually at the rate of 1 percentage point per 3 months thereafter.
+In the September 18, 2025 Executive Vote, the Delayed Upgrade Penalty for the MKR to SKY conversion contract was set to 1%. The Delayed Upgrade Penalty is increased via an Executive Vote by one (1) percentage point every three (3) months thereafter.
+
+###### A.4.1.2.1.3.1 - Current Value [Core]  <!-- UUID: 2b209018-e632-47a4-bc1b-11c5d101c952 -->
+
+The current value of the Delayed Upgrade Penalty can be read from the MKR to SKY conversion contract MKR_SKY, as specified in [A.4.1.2.1.2 - MKR To SKY Conversion Contract](0a26f6d0-1b50-4015-b094-499724796f9e), located on the Ethereum Mainnet at `0xA1Ea1bA18E88C381C724a75F23a130420C403f9a`, by calling the `fee` function [https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a#readContract#F1](https://etherscan.io/address/0xA1Ea1bA18E88C381C724a75F23a130420C403f9a#readContract#F1).
 
 #### A.4.1.2.2 - Deflationary Tokenomics [Core]  <!-- UUID: c72ca16f-14d1-4aca-978e-ba9efe6d80bc -->
 
@@ -231,7 +235,7 @@ The Avalanche SkyLink Bridge consists of a Token Bridge that allows bridging USD
 
 ##### A.4.2.2.3.2 - Deployment [Core]  <!-- UUID: 1c0d2cf1-dc44-4b7f-b709-61fcc5c1612c -->
 
-The Avalanche SkyLink Bridge will be deployed in the April 9, 2026 Executive Vote. The timing may be modified by the Core Facilitator in consultation with relevant Ecosystem Actors.
+The Avalanche SkyLink Bridge was deployed in the April 9, 2026 Executive Vote.
 
 ##### A.4.2.2.3.3 - Security Parameters [Core]  <!-- UUID: 413852e0-23b8-4630-a8a1-de0d9018c482 -->
 
@@ -463,7 +467,7 @@ SKY stakers can unstake their staked SKY at any time without penalty, provided t
 
 #### A.4.4.1.2 - SKY Staking Rewards [Core]  <!-- UUID: a98a1bfe-5713-43f5-a8bd-83c5808900b8 -->
 
-The documents herein define the SKY Staking Rewards. SKY stakers may choose between receiving USDS, SKY, or Agent Token rewards.
+The documents herein define the SKY Staking Rewards. SKY stakers may choose between receiving USDS or SKY rewards. Agent Token rewards may also be made available as specified in [A.4.5 - Distribution Of Agent Tokens](e2f1f01f-3303-41c3-b337-f09eb41ba6be).
 
 ##### A.4.4.1.2.1 - Sources Of Rewards [Core]  <!-- UUID: e1c77a6a-5b94-4d40-a205-43c703a780e2 -->
 
@@ -471,11 +475,99 @@ SKY stakers are eligible to receive rewards sourced from the Sky Treasury Manage
 
 ###### A.4.4.1.2.1.1 - Treasury Management Function-Derived Rewards [Core]  <!-- UUID: 6cacdc1c-bdfa-4f68-bdb4-bf31943dcfba -->
 
-USDS rewards and SKY rewards for SKY stakers are funded from the Staking Rewards allocation of the Sky Treasury Management Function (see [A.2.3.1.2.5 - Step 4: Staking Rewards](bb163691-630e-4fda-88f1-96381a649fa0)) and distributed continuously, pro-rata based on the SKY stake of eligible wallets. Distribution parameters are updated at each Monthly Settlement Cycle.
+USDS rewards and SKY rewards for SKY stakers are funded from the Staking Rewards allocation of the Sky Treasury Management Function (see [A.2.3.1.2.5 - Step 4: Staking Rewards](bb163691-630e-4fda-88f1-96381a649fa0)) and distributed continuously, pro-rata based on the SKY stake of eligible wallets. Distribution parameters are adjusted as specified in [A.2.3.1.4.1 - Staking Rewards Rate Adjustment](de233df4-34cc-4e88-a065-9a9dde9add3c). SKY rewards are funded as specified in [A.4.4.1.2.2.4 - Source Of SKY Rewards](349a350c-c9b7-4232-a83f-2fb49b91fc74) and distributed, at the vesting rate set as specified in [A.2.3.1.4.1 - Staking Rewards Rate Adjustment](de233df4-34cc-4e88-a065-9a9dde9add3c), through the implementation specified in [A.4.4.1.2.2 - SKY Rewards Implementation](ca151bc7-87fc-4749-9776-ea4308817e81).
 
 ###### A.4.4.1.2.1.2 - Agent Token Distribution Rewards [Core]  <!-- UUID: 6aa85298-4f1c-4dc5-a973-99bc1e5293d1 -->
 
-SKY stakers are eligible to receive Agent Token rewards as specified in [A.4.5 - Distribution Of Agent Tokens](e2f1f01f-3303-41c3-b337-f09eb41ba6be). Agent Tokens are distributed continuously, pro‑rata by staked SKY, among wallets that have opted to receive a specific Agent Token. Distribution parameters are updated at each Monthly Settlement Cycle.
+SKY stakers may be eligible to receive Agent Token rewards as specified in [A.4.5 - Distribution Of Agent Tokens](e2f1f01f-3303-41c3-b337-f09eb41ba6be). When available, Agent Tokens are distributed continuously, pro‑rata by staked SKY, among wallets that have opted to receive a specific Agent Token. Distribution parameters are updated at each Monthly Settlement Cycle.
+
+##### A.4.4.1.2.2 - SKY Rewards Implementation [Core]  <!-- UUID: ca151bc7-87fc-4749-9776-ea4308817e81 -->
+
+The documents herein specify the implementation and funding of SKY rewards for SKY stakers through the Staking Rewards contract, Rewards Distribution contract, and Vesting Stream contract.
+
+###### A.4.4.1.2.2.1 - Staking Rewards Contract [Core]  <!-- UUID: cf65f0d8-ae2f-45df-80bd-1014ce66509d -->
+
+The Staking Rewards contract is the user facing contract that allows SKY stakers to stake their SKY to receive SKY rewards. It maintains the balance of staked SKY receiving SKY rewards for each user and the associated accumulated rewards balance.
+
+###### A.4.4.1.2.2.1.1 - Staking Rewards Contract Address [Core]  <!-- UUID: b4989cd9-f45e-4747-8861-fac4175624cc -->
+
+The address of the Staking Rewards contract on the Ethereum Mainnet is `0xB44C2Fb4181D7Cb06bdFf34A46FdFe4a259B40Fc`.
+
+###### A.4.4.1.2.2.1.2 - Staking Rewards Contract Parameters [Core]  <!-- UUID: 2bfed9a4-9d7f-4544-b331-5e196a13a108 -->
+
+The parameters of the Staking Rewards contract are specified in the documents herein.
+
+###### A.4.4.1.2.2.1.2.1 - Owner [Core]  <!-- UUID: 3db49535-c663-425d-81b9-3ffa6e2e722d -->
+
+The `owner` of the Staking Rewards contract is the contract that has the ability to control administrative functions for the Staking Rewards contract. The value of the `owner` parameter is the `MCD_PAUSE_PROXY`.
+
+###### A.4.4.1.2.2.1.2.2 - Rewards Distribution Contract Address [Core]  <!-- UUID: 12b11af8-08d6-4b42-a323-cac0a60e78d3 -->
+
+The Rewards Distribution contract address `rewardsDistribution` is the address of the Rewards Distribution contract associated with the Staking Rewards contract. The value of the `rewardsDistribution` parameter is the address of the Rewards Distribution contract specified in [A.4.4.1.2.2.2.1 - Rewards Distribution Contract Address](fdebe206-2f58-4056-8adf-c42dffb47026).
+
+###### A.4.4.1.2.2.1.2.3 - Rewards Token [Core]  <!-- UUID: 9c3bd61a-25ee-43bc-8c93-89142dce6b49 -->
+
+The Rewards Token `rewardsToken` is the token that users receive as rewards. The value of the `rewardsToken` parameter is `SKY`, representing SKY Tokens.
+
+###### A.4.4.1.2.2.1.2.4 - Staking Token [Core]  <!-- UUID: 7e88d6b2-a76b-4aae-a045-bc0eb44d9657 -->
+
+The Staking Token `stakingToken` is the token that users stake to earn rewards. The value of the `stakingToken` parameter is `LSSKY`, representing staked SKY Tokens.
+
+###### A.4.4.1.2.2.2 - Rewards Distribution Contract [Core]  <!-- UUID: 1317764a-d07f-40de-8ff7-f43a3337ca19 -->
+
+The Rewards Distribution contract is the contract that handles the regular transfer of reward tokens from the Vesting Stream contract to the Staking Rewards contract for distribution to end users.
+
+###### A.4.4.1.2.2.2.1 - Rewards Distribution Contract Address [Core]  <!-- UUID: fdebe206-2f58-4056-8adf-c42dffb47026 -->
+
+The address of the Rewards Distribution contract on the Ethereum Mainnet is `0x675671A8756dDb69F7254AFB030865388Ef699Ee`.
+
+###### A.4.4.1.2.2.2.2 - Rewards Distribution Contract Parameters [Core]  <!-- UUID: c13efebc-94fe-408f-93a7-5ee5badb109f -->
+
+The parameters of the Rewards Distribution contract are specified in the documents herein.
+
+###### A.4.4.1.2.2.2.2.1 - Staking Rewards Contract Address [Core]  <!-- UUID: dd30a514-3abb-4e2b-8cc3-03ef2fbf7834 -->
+
+The Staking Rewards contract address `stakingRewards` is the address of the Staking Rewards contract associated with the Rewards Distribution contract. The value of the `stakingRewards` parameter is the address of the Staking Rewards contract specified in [A.4.4.1.2.2.1.1 - Staking Rewards Contract Address](b4989cd9-f45e-4747-8861-fac4175624cc).
+
+###### A.4.4.1.2.2.2.2.2 - Vesting Stream Contract Address [Core]  <!-- UUID: 5348e6c1-13f4-4e5c-8d75-83239ad999ea -->
+
+The Vesting Stream contract address `dssVest` is the address of the Vesting Stream contract associated with the Rewards Distribution contract. The value of the `dssVest` parameter is the address of the Vesting Stream contract specified in [A.4.4.1.2.2.3.1 - Vesting Stream](89155294-6652-481f-938f-a562d5b40e65).
+
+###### A.4.4.1.2.2.3 - Vesting Stream Contract [Core]  <!-- UUID: 21a8978d-10a5-4151-b99a-ca8115fe0a6d -->
+
+The Vesting Stream contract manages various vesting streams that vest SKY Tokens from the Protocol Treasury. One of these vesting streams regularly vests SKY Tokens to the Staking Rewards contract.
+
+###### A.4.4.1.2.2.3.1 - Vesting Stream [Core]  <!-- UUID: 89155294-6652-481f-938f-a562d5b40e65 -->
+
+The address of the Vesting Stream contract is the address corresponding to the `MCD_VEST_SKY_TREASURY` key in the Chainlog.
+
+###### A.4.4.1.2.2.3.2 - Vesting Stream Contract Parameters [Core]  <!-- UUID: 148e2c86-0f30-49c1-923c-9b32f92aa40f -->
+
+The parameters of the vesting stream managed by the Vesting Stream contract that vests SKY Tokens to the Staking Rewards contract are specified in the documents herein.
+
+###### A.4.4.1.2.2.3.2.1 - Vesting Duration [Core]  <!-- UUID: 9cad1b65-5dea-4510-a1cd-c47eddb66309 -->
+
+The Vesting Duration `vestTau` is the total duration over which the Vesting Total number of tokens are to be vested linearly.
+
+###### A.4.4.1.2.2.3.2.2 - Vesting Total [Core]  <!-- UUID: 8bc59b3a-5bf4-4e2c-a793-b51a4ff58ef6 -->
+
+The Vesting Total `vestTot` is the number of rewards tokens to be vested in total over the Vesting Duration.
+
+###### A.4.4.1.2.2.3.3 - Vesting Stream Parameter Modification [Core]  <!-- UUID: 7da0cd7a-238f-400f-89a7-a419ed25ce37 -->
+
+The Core Facilitator, in consultation with the Core Council Risk Advisor, may modify the parameters of the vesting stream to achieve the target reward rate as specified in [A.2.3.1.4.1 - Staking Rewards Rate Adjustment](de233df4-34cc-4e88-a065-9a9dde9add3c). Such modifications can be effected directly via an Executive Vote, without a prior Governance Poll.
+
+###### A.4.4.1.2.2.4 - Source Of SKY Rewards [Core]  <!-- UUID: 349a350c-c9b7-4232-a83f-2fb49b91fc74 -->
+
+SKY rewards distributed through the Vesting Stream contract are funded by SKY acquired through Smart Burn Engine buybacks attributable to the SKY Staking Rewards share specified in [A.2.3.1.2.4 - Step 3: Smart Burn Engine](5ce73730-4d5d-479c-b01e-40e87f072121). The `vestTot` and `vestTau` parameters are set accordingly.
+
+###### A.4.4.1.2.2.4.1 - Authorization Of Transfer By Sky Frontier Foundation [Core]  <!-- UUID: 2789177b-5bc7-486f-8aab-75ea16e21035 -->
+
+Sky Governance hereby confirms that the transfer of 500,000,000 SKY tokens to initially fund SKY rewards for SKY stakers is consistent with the terms of the grant to the Sky Frontier Foundation. See [A.2.13.1 - Ecosystem Entity Grants](5d5759e4-8077-4af5-9a1a-eaeab5088dd7).
+
+##### A.4.4.1.2.3 - USDS Rewards Implementation [Core]  <!-- UUID: 75784a6a-c6e2-4f74-a92c-dd1ac4f8f124 -->
+
+USDS rewards for SKY stakers are distributed through the USDS rewards contract at the address corresponding to the `REWARDS_LSSKY_USDS` key in the Chainlog. The contract is funded directly by the Splitter Module from the share of Step 3 Capital allocated to USDS Staking Rewards, as specified in [A.2.3.1.4 - Implementation](f67a5780-11d5-4014-8254-795080c77133). Its `rewardsDuration` parameter is maintained equal to the Splitter Module's `hop` parameter as specified in [A.3.5.2 - Smart Burn Engine Parameters](ddb90fee-2851-4bf0-b924-f1d73e30ce7a).
 
 #### A.4.4.1.3 - SKY-Backed Borrowing [Core]  <!-- UUID: 264b1787-cd75-4d28-9c14-c7d5a724eba7 -->
 
@@ -1080,102 +1172,6 @@ The Core Facilitator, in consultation with the Core Council Risk Advisor, has th
 The current value of the `cap` parameter is:
 
 - 0.025 USDS.
-
-#### A.4.4.1.4 - Short Term Transitionary Measures [Core]  <!-- UUID: 22b8f8bf-b477-4439-86f7-ec605d3c657a -->
-
-The documents herein define the implementation of short-term SKY staking rewards pending the full implementation of the Sky Treasury Management Function. The policy governing the allocation of capital to staking rewards is specified in [A.2.3.1.2.5 - Step 4: Staking Rewards](bb163691-630e-4fda-88f1-96381a649fa0).
-
-##### A.4.4.1.4.1 - Short Term USDS Rewards For SKY Stakers [Core]  <!-- UUID: aad249a0-1332-4b5f-9b46-d89873e73b86 -->
-
-USDS rewards for SKY stakers are available as specified in [A.2.3.1.2.5 - Step 4: Staking Rewards](bb163691-630e-4fda-88f1-96381a649fa0).
-
-##### A.4.4.1.4.2 - Short Term SKY Rewards For SKY Stakers [Core]  <!-- UUID: aed6511f-f5f0-4b46-a56e-9a7bbc6ea310 -->
-
-Pending activation of the USDS Staking Rewards specified in [A.2.3.1.2.4 - Step 3: Smart Burn Engine](5ce73730-4d5d-479c-b01e-40e87f072121), SKY rewards for SKY stakers are funded by SKY from the Protocol Treasury at the rate specified in [A.2.3.1.4.1 - Short Term SKY Staking Rewards Rate](de233df4-34cc-4e88-a065-9a9dde9add3c) and through the implementation specified in [A.4.4.1.4.2.1 - Implementation](ca151bc7-87fc-4749-9776-ea4308817e81); this interim mechanism will be discontinued once the USDS Staking Rewards become operational.
-
-###### A.4.4.1.4.2.1 - Implementation [Core]  <!-- UUID: ca151bc7-87fc-4749-9776-ea4308817e81 -->
-
-SKY rewards for SKY stakers are implemented through the Staking Rewards contract, the Vested Rewards Distribution contract, and the Vesting Stream contract, as specified in the documents herein.
-
-###### A.4.4.1.4.2.1.1 - Staking Rewards Contract [Core]  <!-- UUID: cf65f0d8-ae2f-45df-80bd-1014ce66509d -->
-
-The Staking Rewards contract is the user facing contract that allows SKY stakers to stake their SKY to receive SKY rewards. It maintains the balance of staked SKY receiving SKY rewards for each user and the associated accumulated rewards balance.
-
-###### A.4.4.1.4.2.1.1.1 - Staking Rewards Contract Address [Core]  <!-- UUID: b4989cd9-f45e-4747-8861-fac4175624cc -->
-
-The address of the Staking Rewards contract on the Ethereum Mainnet is `0xB44C2Fb4181D7Cb06bdFf34A46FdFe4a259B40Fc`.
-
-###### A.4.4.1.4.2.1.1.2 - Staking Rewards Contract Parameters [Core]  <!-- UUID: 2bfed9a4-9d7f-4544-b331-5e196a13a108 -->
-
-The parameters of the Staking Rewards contract are specified in the documents herein.
-
-###### A.4.4.1.4.2.1.1.2.1 - Owner [Core]  <!-- UUID: 3db49535-c663-425d-81b9-3ffa6e2e722d -->
-
-The `owner` of the Staking Rewards contract is the contract that has the ability to control administrative functions for the Staking Rewards contract. The value of the `owner` parameter is the `MCD_PAUSE_PROXY`.
-
-###### A.4.4.1.4.2.1.1.2.2 - Rewards Distribution Contract Address [Core]  <!-- UUID: 12b11af8-08d6-4b42-a323-cac0a60e78d3 -->
-
-The Rewards Distribution contract address `rewardsDistribution` is the address of the Rewards Distribution contract associated with the Staking Rewards contract. The value of the `rewardsDistribution` parameter is the address of the Rewards Distribution contract specified in [A.4.4.1.4.2.1.2.1 - Rewards Distribution Contract Address](fdebe206-2f58-4056-8adf-c42dffb47026).
-
-###### A.4.4.1.4.2.1.1.2.3 - Rewards Token [Core]  <!-- UUID: 9c3bd61a-25ee-43bc-8c93-89142dce6b49 -->
-
-The Rewards Token `rewardsToken` is the token that users receive as rewards. The value of the `rewardsToken` parameter is `SKY`, representing SKY Tokens.
-
-###### A.4.4.1.4.2.1.1.2.4 - Staking Token [Core]  <!-- UUID: 7e88d6b2-a76b-4aae-a045-bc0eb44d9657 -->
-
-The Staking Token `stakingToken` is the token that users stake to earn rewards. The value of the `stakingToken` parameter is `LSSKY`, representing staked SKY Tokens.
-
-###### A.4.4.1.4.2.1.2 - Rewards Distribution Contract [Core]  <!-- UUID: 1317764a-d07f-40de-8ff7-f43a3337ca19 -->
-
-The Rewards Distribution contract is the contract that handles the regular transfer of reward tokens from the Vesting Stream contract to the Staking Rewards contract for distribution to end users.
-
-###### A.4.4.1.4.2.1.2.1 - Rewards Distribution Contract Address [Core]  <!-- UUID: fdebe206-2f58-4056-8adf-c42dffb47026 -->
-
-The address of the Rewards Distribution contract on the Ethereum Mainnet is `0x675671A8756dDb69F7254AFB030865388Ef699Ee`.
-
-###### A.4.4.1.4.2.1.2.2 - Rewards Distribution Contract Parameters [Core]  <!-- UUID: c13efebc-94fe-408f-93a7-5ee5badb109f -->
-
-The parameters of the Rewards Distribution contract are specified in the documents herein.
-
-###### A.4.4.1.4.2.1.2.2.1 - Staking Rewards Contract Address [Core]  <!-- UUID: dd30a514-3abb-4e2b-8cc3-03ef2fbf7834 -->
-
-The Staking Rewards contract address `stakingRewards` is the address of the Staking Rewards contract associated with the Rewards Distribution contract. The value of the `stakingRewards` parameter is the address of the Staking Rewards contract specified in [A.4.4.1.4.2.1.1.1 - Staking Rewards Contract Address](b4989cd9-f45e-4747-8861-fac4175624cc).
-
-###### A.4.4.1.4.2.1.2.2.2 - Vesting Stream Contract Address [Core]  <!-- UUID: 5348e6c1-13f4-4e5c-8d75-83239ad999ea -->
-
-The Vesting Stream contract address `dssVest` is the address of the Vesting Stream contract associated with the Rewards Distribution contract. The value of the `dssVest` parameter is the address of the Vesting Stream contract specified in [A.4.4.1.4.2.1.3.1 - Vesting Stream](89155294-6652-481f-938f-a562d5b40e65).
-
-###### A.4.4.1.4.2.1.3 - Vesting Stream Contract [Core]  <!-- UUID: 21a8978d-10a5-4151-b99a-ca8115fe0a6d -->
-
-The Vesting Stream contract manages various vesting streams that vest SKY Tokens from the Protocol Treasury. One of these vesting streams regularly vests SKY Tokens to the Staking Rewards contract.
-
-###### A.4.4.1.4.2.1.3.1 - Vesting Stream [Core]  <!-- UUID: 89155294-6652-481f-938f-a562d5b40e65 -->
-
-The address of the Vesting Stream contract is the address corresponding to the `MCD_VEST_SKY_TREASURY` key in the Chainlog.
-
-###### A.4.4.1.4.2.1.3.2 - Vesting Stream Contract Parameters [Core]  <!-- UUID: 148e2c86-0f30-49c1-923c-9b32f92aa40f -->
-
-The parameters of the vesting stream managed by the Vesting Stream contract that vests SKY Tokens to the Staking Rewards contract are specified in the documents herein.
-
-###### A.4.4.1.4.2.1.3.2.1 - Vesting Duration [Core]  <!-- UUID: 9cad1b65-5dea-4510-a1cd-c47eddb66309 -->
-
-The Vesting Duration `vestTau` is the total duration over which the Vesting Total number of tokens are to be vested linearly.
-
-###### A.4.4.1.4.2.1.3.2.2 - Vesting Total [Core]  <!-- UUID: 8bc59b3a-5bf4-4e2c-a793-b51a4ff58ef6 -->
-
-The Vesting Total `vestTot` is the number of rewards tokens to be vested in total over the Vesting Duration.
-
-###### A.4.4.1.4.2.1.3.3 - Vesting Stream Parameter Modification [Core]  <!-- UUID: 7da0cd7a-238f-400f-89a7-a419ed25ce37 -->
-
-The Core Facilitator, in consultation with the Core Council Risk Advisor, may modify the parameters of the vesting stream to achieve the target reward rate as specified in [A.2.3.1.4.1 - Short Term SKY Staking Rewards Rate](de233df4-34cc-4e88-a065-9a9dde9add3c). Such modifications can be effected directly via an Executive Vote, without a prior Governance Poll.
-
-###### A.4.4.1.4.2.2 - Source Of SKY Rewards [Core]  <!-- UUID: 349a350c-c9b7-4232-a83f-2fb49b91fc74 -->
-
-The `vestTot` and `vestTau` parameters of the Vesting Stream contract are set such that SKY rewards are funded by SKY acquired through buybacks or SKY reserves.
-
-###### A.4.4.1.4.2.2.1 - Authorization Of Transfer By Sky Frontier Foundation [Core]  <!-- UUID: 2789177b-5bc7-486f-8aab-75ea16e21035 -->
-
-Sky Governance hereby confirms that the transfer of 500,000,000 SKY tokens to initially fund SKY rewards for SKY stakers is consistent with the terms of the grant to the Sky Frontier Foundation. See [A.2.13.1 - Ecosystem Entity Grants](5d5759e4-8077-4af5-9a1a-eaeab5088dd7).
 
 ## A.4.5 - Distribution Of Agent Tokens [Article]  <!-- UUID: e2f1f01f-3303-41c3-b337-f09eb41ba6be -->
 

--- a/content/A.6.1.1.7 - Osero.md
+++ b/content/A.6.1.1.7 - Osero.md
@@ -1276,17 +1276,29 @@ The address of the AdministeredAgent contract is: `0x1837505D104F7a6D8b7e1945261
 
 The documents herein list the rate limits for the Osero Liquidity Layer Diamond PAU.
 
-###### A.6.1.1.7.2.6.1.2.1.1.2.1 - Diamond PAU Rate Limits [Core]  <!-- UUID: 325731dc-5e89-4a8a-9d64-91b203febf48 -->
+###### A.6.1.1.7.2.6.1.2.1.1.2.1 - Diamond PAU Rate Limit IDs [Core]  <!-- UUID: eeaa3936-6129-4af5-89a1-0a3c56c175aa -->
 
-The documents herein list the Diamond PAU rate limits for the Osero Liquidity Layer.
+The documents herein list the controller-wide `RateLimitID`(s) for the Osero Diamond PAU. Instance-specific `RateLimitID`(s) are specified in each Instance Configuration Document.
 
-###### A.6.1.1.7.2.6.1.2.1.1.2.1.1 - USDS Mint Maximum [Core]  <!-- UUID: c6456279-0dab-4517-aad9-46d9e8d4aede -->
+###### A.6.1.1.7.2.6.1.2.1.1.2.1.1 - USDS Mint RateLimitID [Core]  <!-- UUID: faa9b57b-a127-433d-9330-b52f9c455108 -->
+
+The LIMIT_USDS_MINT RateLimitID is: `0xcb0537d5e5dba65a8edbac12555995860e5b8e1b70996011edb1ca8173e56d3c`.
+
+###### A.6.1.1.7.2.6.1.2.1.1.2.1.2 - USDS Burn RateLimitID [Core]  <!-- UUID: 6546d1fc-06dc-4169-aca1-f3c1e6b1c71f -->
+
+The LIMIT_USDS_BURN RateLimitID is: `0x844d35ae585cfdeed0a77b7724286a1d4b5718bf8663d85e55396062b1cbe38c`.
+
+###### A.6.1.1.7.2.6.1.2.1.1.2.2 - Diamond PAU Rate Limits [Core]  <!-- UUID: 325731dc-5e89-4a8a-9d64-91b203febf48 -->
+
+The documents herein list the controller-wide rate limits for the Osero Diamond PAU on Ethereum Mainnet. Instance-specific rate limits are specified in each Instance Configuration Document. These values are set via a cBEAM, which updates the on-chain value incrementally, through bounded adjustments, as specified in [A.2.2.10.1.1.1.2.4.4.1 - Operator Execution](7a98000b-c069-42f3-b1a4-8a3e7323a960). The current on-chain value can be queried, as specified in [A.2.2.10.1.1.1.2.5.3.1 - RateLimits Query](1cb17b82-a294-4942-8183-4d90b224a79d).
+
+###### A.6.1.1.7.2.6.1.2.1.1.2.2.1 - USDS Mint Maximum [Core]  <!-- UUID: c6456279-0dab-4517-aad9-46d9e8d4aede -->
 
 The maximum amount of USDS that can be minted by the Osero Diamond PAU (`LIMIT_USDS_MINT`) is specified in the document herein.
-- `maxAmount`: 5,000,000 USDS
-- `slope`: 5,000,000 USDS per day
+- `maxAmount`: 50,000,000 USDS
+- `slope`: 50,000,000 USDS per day
 
-###### A.6.1.1.7.2.6.1.2.1.1.2.1.2 - USDS Burn Maximum [Core]  <!-- UUID: eafa2031-9560-4b23-aa7a-f4ee62097438 -->
+###### A.6.1.1.7.2.6.1.2.1.1.2.2.2 - USDS Burn Maximum [Core]  <!-- UUID: eafa2031-9560-4b23-aa7a-f4ee62097438 -->
 
 The maximum amount of USDS that can be burned by the Osero Diamond PAU (`LIMIT_USDS_BURN`) is specified in the document herein.
 - `maxAmount`: Unlimited
@@ -1409,7 +1421,7 @@ The documents herein define the protocol for routine ongoing management of the O
 
 ###### A.6.1.1.7.2.6.1.2.2.1.1 - Role Hierarchies And Permissions [Core]  <!-- UUID: aae0e1ba-4ed0-4484-9187-3e53f3695ae8 -->
 
-The roles and permissions of the Diamond PAU Instance are the Liquidity Layer roles defined in [A.2.2.10.1.1.1.2.2 - Liquidity Layer Role Definitions](2ae4b91a-6900-41e8-9718-32805b956550), managed by the AccessControls contract. For the Osero Liquidity Layer, the `DEFAULT_ADMIN_ROLE` is held by the Osero SubProxy, and the `CONTROLLER` role by the Controller contract. The `ALLOCATOR_ROLE` is held by the AdministeredAgent contract, as specified in [A.6.1.1.7.2.6.1.2.1.1.1.2.1.5 - AdministeredAgent Contract](0eed3609-62a2-4c5b-ae5b-4f78212252ee). The Osero Relayer Multisig ([A.6.1.1.7.2.6.1.2.1.2.1.1 - Osero Relayer Multisig](1830fb80-a44b-4aaf-b72c-7c4997cb9486)) and the Core Operator Relayer Multisig ([A.6.1.1.7.2.6.1.2.1.2.1.2 - Core Operator Relayer Multisig](f48b14c7-6dd1-4d10-b546-a604be45758c)) are registered as its Actors, as specified in [A.2.2.10.1.1.1.2.2.4 - Actor](636a39e4-5908-4fee-bae8-e0b11e0d9c55). The Freezer Multisig ([A.6.1.1.7.2.6.1.2.1.2.1.3 - Freezer Multisig](51460bc2-f5fb-4302-912a-ed3e6943aae0)) is registered as a Revoker, as specified in [A.2.2.10.1.1.1.2.2.5 - Revoker](cc7cb4b7-981e-44f5-a0d5-62e5b47d112e).
+The roles and permissions of the Diamond PAU Instance are the Liquidity Layer roles defined in [A.2.2.10.1.1.1.2.2 - Liquidity Layer Role Definitions](2ae4b91a-6900-41e8-9718-32805b956550), managed by the AccessControls contract. For the Osero Liquidity Layer, the `DEFAULT_ADMIN_ROLE` is held by the Osero SubProxy, and the `CONTROLLER` role by the Controller contract. The Configurator also holds the `DEFAULT_ADMIN_ROLE` on both the AccessControls contract and the ALM Rate Limits contract, as specified in [A.2.2.10.1.1.1.2.3.6 - Configurator](5e1f82c7-bcd6-46f8-aec0-3e767e55a93c). The `ALLOCATOR_ROLE` is held by the AdministeredAgent contract, as specified in [A.6.1.1.7.2.6.1.2.1.1.1.2.1.5 - AdministeredAgent Contract](0eed3609-62a2-4c5b-ae5b-4f78212252ee). The Osero Relayer Multisig ([A.6.1.1.7.2.6.1.2.1.2.1.1 - Osero Relayer Multisig](1830fb80-a44b-4aaf-b72c-7c4997cb9486)) and the Core Operator Relayer Multisig ([A.6.1.1.7.2.6.1.2.1.2.1.2 - Core Operator Relayer Multisig](f48b14c7-6dd1-4d10-b546-a604be45758c)) are registered as its Actors, as specified in [A.2.2.10.1.1.1.2.2.4 - Actor](636a39e4-5908-4fee-bae8-e0b11e0d9c55). The Freezer Multisig ([A.6.1.1.7.2.6.1.2.1.2.1.3 - Freezer Multisig](51460bc2-f5fb-4302-912a-ed3e6943aae0)) is registered as a Revoker, as specified in [A.2.2.10.1.1.1.2.2.5 - Revoker](cc7cb4b7-981e-44f5-a0d5-62e5b47d112e).
 
 ###### A.6.1.1.7.2.6.1.2.2.1.2 - Controller Functions [Core]  <!-- UUID: 14aa9d85-4878-49b9-9cd7-d6a014bdecea -->
 
@@ -1521,13 +1533,13 @@ The outflow RateLimitID is: `0xf9ac1455c7ba8e0bacb7a3eca4a2cf412eda3cbc0f6aa1b07
 
 ###### A.6.1.1.7.2.6.1.3.1.1.1.2.4 - Rate Limits [Core]  <!-- UUID: d0d163d7-b9d3-4e7d-9371-0a8c48bf2d9f -->
 
-The current `maxAmount` and `slope` for this conduit's inflow/outflow are defined in the subdocuments herein.
+The current `maxAmount` and `slope` for this conduit's inflow/outflow are defined in the subdocuments herein. These values are set via a cBEAM, as specified in [A.6.1.1.7.2.6.1.2.1.1.2.2 - Diamond PAU Rate Limits](325731dc-5e89-4a8a-9d64-91b203febf48).
 
 ###### A.6.1.1.7.2.6.1.3.1.1.1.2.4.1 - Deposit Rate Limits [Core]  <!-- UUID: e3b12e29-eb67-40be-8cac-85913eff958c -->
 
 The deposit rate limits are:
-- `maxAmount`: 5,000,000 USDS
-- `slope`: 5,000,000 USDS per day
+- `maxAmount`: 50,000,000 USDS
+- `slope`: 50,000,000 USDS per day
 
 ###### A.6.1.1.7.2.6.1.3.1.1.1.2.4.2 - Withdrawal Rate Limits [Core]  <!-- UUID: b021fcff-b1e3-456d-a1e6-f14604784100 -->
 


### PR DESCRIPTION
## Summary

This proposal includes the following edits:

- **Equalize Staking Reward Rates Across Reward Options** - Keeps the SKY and USDS staking reward rates equivalent by adjusting the Step 3 Capital split and the vesting stream rate.
- **Add Morpho Vault Curation Framework** - Sets the requirements for Morpho vaults that Prime Agents deploy capital into, covering roles, eligible markets, oracles and timelocks. Allocations to noncompliant Morpho vaults carry a 100% Instance Financial CRR after the October 8, 2026 Executive Vote.
- **Clarify How Core Governance Rewards Are Paid** - Specifies that each Prime Agent's Core Governance Reward is paid from the Core Council Buffer following the Final Calculation for each Monthly Settlement Cycle, and funded out of the Core Council Allocation. Confirms these rewards are not part of the net amounts settled under the Monthly Settlement Cycle and do not reduce Net Revenue.
- **Update Osero Artifact For September 24, 2026 Spell** - Updates the Osero Artifact for the actions planned in the September 24, 2026 spell, including giving the PAS Configurator authority over Osero's AccessControls and ALM Rate Limits contracts, and increasing the USDS mint and SparkLend USDS deposit rate limits from 5 million to 50 million USDS.
- **Add Grove Foundation Grant Authorization: September 2026** - Authorizes an 800,000 USDS grant from Grove's Prime Treasury to the Grove Foundation to cover September 2026 expenses.
- **Add Spark Foundation Grant Authorization: October 2026** - Authorizes two grants from Spark's Prime Treasury to cover October 2026 expenses: 865,000 USDS to the Spark Foundation and 45,000 USDS to the Spark Asset Foundation.
- **Specify Forum Category And Title Convention For Prime Spell Action Publications** - Requires each Prime Agent to publish its Spell action Forum posts under its own category, and sets a standard format for their titles.
- **Document The MKR To SKY Upgrade Penalty's Live Value** - Gives readers a way to look up the Delayed Upgrade Penalty's current value directly from the MKR to SKY conversion contract.
- **Update Two Deployment Documents To Past Tense** - Corrects the tense of the Kicker Module activation and the Avalanche SkyLink Bridge deployment now that both have occurred.
